### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 
-**PHP Insights** created and maintained by [Nuno Maduro](https://github.com/nunomaduro), is the perfect starting point to analyze the code quality of your PHP projects. 
+**PHP Insights** created and maintained by [Nuno Maduro](https://github.com/nunomaduro), is the perfect starting point to analyze the code quality of your PHP projects.
 Carefully crafted to simplify the analysis of your code directly on your terminal.
 
 **🚨 This project is under development. Don't use it!**.
@@ -47,7 +47,7 @@ php ./vendor/bin/phpinsights
 You can publish the config-file with:
 
 ```bash
-php artisan vendor:publish --provider="NunoMaduro\PhpInsights\Application\Adapters\Laravel\InsightsServiceProvider" 
+php artisan vendor:publish --provider="NunoMaduro\PhpInsights\Application\Adapters\Laravel\InsightsServiceProvider"
 ```
 
 Open `config/insights.php`, and update the preset to `laravel`.
@@ -95,7 +95,7 @@ final class ForbiddenFinalClasses extends Insight
 final class ClassesFinal implements HasValue, HasPercentage, HasInsights
 {
     // ...
-    
+
     /**
      * {@inheritdoc}
      */
@@ -109,4 +109,4 @@ final class ClassesFinal implements HasValue, HasPercentage, HasInsights
 ```
 
 ## 🆓 License
-PHP Insights is an open-sourced software licensed under the [MIT license](LICENSE.md).
+PHP Insights is open-sourced software licensed under the [MIT license](LICENSE.md).


### PR DESCRIPTION
"software" is an uncountable noun, so "an open-sourced software" is incorrect. I just help to fix it.
https://www.oxfordlearnersdictionaries.com/definition/english/software?q=software

There are some trailing spaces that are removed automatically by my editor on saving.
