### PR TITLE
Clean phpinsights executable file

### DIFF
--- a/phpinsights
+++ b/phpinsights
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 (function () {
     require file_exists(__DIR__ . '/vendor/autoload.php')
         ? __DIR__ . '/vendor/autoload.php'
-        : __DIR__ . '/../../../vendor/autoload.php';
+        : __DIR__ . '/../../vendor/autoload.php';
 
     /**
      * Bootstraps the domain kernel.
@@ -23,11 +23,6 @@ use Symfony\Component\Console\Input\ArgvInput;
     $commands = require __DIR__ . '/config/routes/console.php';
 
     /**
-     * Capture the input from globals.
-     */
-    $input = new ArgvInput();
-
-    /**
      * Creates a new console application, and runs it.
      */
     $application = new Application('PHP Insights', 'v1.0.0');
@@ -38,7 +33,5 @@ use Symfony\Component\Console\Input\ArgvInput;
     $application->addCommands($commands);
     $application->setDefaultCommand('analyse');
 
-    $application->run($input);
+    $application->run();
 })();
-
-


### PR DESCRIPTION
- Because the executable file is placed under the package directory, it is located at `vendor/nunomaduro/phpinsights/phpinsights` when this package is installed as a dependency. Therefore, you have to go back 2 steps in directory to see the `autoload.php` file, not 3 steps.

- The console run method will create an ArgvInput automatically if you don't pass any inputs into it. Therefore, you needn't to care about the input instance this situation. See [this line](https://github.com/symfony/symfony/blob/6e8529f82ec4c7ddb99c6330c0443ed4e0efbb48/src/Symfony/Component/Console/Application.php#L115) for the details!