### PR TITLE
Add test composer script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ before_script:
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-    - vendor/bin/phpstan analyse
-    - vendor/bin/ecs check src --config vendor/symplify/easy-coding-standard/config/clean-code.yml
+    - composer run test

--- a/composer.json
+++ b/composer.json
@@ -53,5 +53,14 @@
     },
     "bin": [
         "phpinsights"
-    ]
+    ],
+    "scripts": {
+        "test": [
+            "phpstan analyse --ansi",
+            "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml"
+        ]
+    },
+    "scripts-descriptions": {
+        "test": "Run all tests including phpstan and esc."
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -55,12 +55,16 @@
         "phpinsights"
     ],
     "scripts": {
+        "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml",
+        "phpstan:test": "phpstan analyse --ansi",
         "test": [
-            "phpstan analyse --ansi",
-            "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml"
+            "@phpstan:test",
+            "@ecs:test"
         ]
     },
     "scripts-descriptions": {
-        "test": "Run all tests including phpstan and esc."
+        "ecs:test": "Run the ecs tests.",
+        "phpstan:test": "Run the phpstan tests.",
+        "test": "Run all tests including phpstan and ecs."
     }
 }


### PR DESCRIPTION
We can compose all tests into only one composer script. Let's see how convenient it is.

```bash
$ composer run --list
scripts:
  ecs:test      Run the ecs tests.                        
  phpstan:test  Run the phpstan tests.                    
  test          Run all tests including phpstan and ecs.

$ composer run test
> phpstan analyse --ansi
Note: Using configuration file /home/xuanquynh/Documents/Projects/nunomaduro/phpinsights/phpstan.neon.dist.
 83/83 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                
 [OK] No errors                                                                 
                                                                                

> ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml
EasyCodingStandard v5.4.16
Config file: /home/xuanquynh/Documents/Projects/nunomaduro/phpinsights/vendor/symplify/easy-coding-standard/config/clean-code.yml

                                                                                
 [OK] No errors found. Great job - your code is shiny in style!                 
                                                                                
```
