### PR TITLE
Add forbidden dump functions to Laravel preset

### DIFF
--- a/src/Application/Adapters/Laravel/Preset.php
+++ b/src/Application/Adapters/Laravel/Preset.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\PhpInsights\Application\Adapters\Laravel;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineGlobalConstants;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
 /**
  * @internal
@@ -45,6 +46,12 @@ final class Preset implements PresetContract
             'config' => [
                 ForbiddenDefineGlobalConstants::class => [
                     'ignore' => ['LARAVEL_START'],
+                ],
+                ForbiddenFunctionsSniff::class => [
+                    'forbiddenFunctions' => [
+                        'dd' => null,
+                        'dump' => null,
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
This adds `dd` and `dump` to the forbidden functions in the [Laravel preset](https://github.com/pxgamer/phpinsights/blob/111bd7bfd9f5b7b378e58176265d965266dbf066/src/Application/Adapters/Laravel/Preset.php).

I've tested it locally. I did try using the code mentioned in https://github.com/nunomaduro/phpinsights/issues/12#issuecomment-490576671, however this didn't seem to work correctly.

Closes #12

----

P.S. I don't think this follows the Style CI guidelines for Symfony, but not sure that's actually enabled as the rest of the code also doesn't follow it.