### PR TITLE
Ignore ide_helper_models

### DIFF
--- a/src/Application/Adapters/Laravel/Preset.php
+++ b/src/Application/Adapters/Laravel/Preset.php
@@ -36,6 +36,7 @@ final class Preset implements PresetContract
                 'database',
                 'server.php',
                 '_ide_helper.php',
+                '_ide_helper_models.php',
                 'public',
             ],
             'add' => [


### PR DESCRIPTION
In addition to #46 it would be nice to ignore the _ide_helper_models.php file too, generated by the same package, as alot of errors are coming from this helper file. 