### PR TITLE
Add exit status code - #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ You may customize `insights` creating and editing the configuration file:
 cp vendor/nunomaduro/phpinsights/stubs/config.php phpinsights.php
 ```
 
+### Within Continuous Integration (CI)
+
+You can launch `phpinsights` in your CI by defining level you want to reach with options `--min-quality`, `--min-complexity`, `--min-architecture`, `--min-style`. 
+If the level is not reached, an exit status code will be thrown.
+
+```bash
+# For laravel
+php artisan insights --no-interaction --min-quality=75 --min-complexity=75 --min-architecture=75 --min-style=75 
+# otherwise
+./vendor/bin/phpinsights --no-interaction --min-quality=75 --min-complexity=75 --min-architecture=75 --min-style=75
+```
+
+The `--no-interaction` option is mandatory when it's launch in CI to avoid prompts.
+All others are optionnal, so if you want focus only on style, add the `--min-style` and forget others.
+
 ### Display issues omitted
 
 PHP Insights console command have different verbosity levels, which determine the quantity of issues displayed. By default, commands display only the 3 first issues per `Insight`, but you can display them all with the `-v` option:

--- a/config/routes/console.php
+++ b/config/routes/console.php
@@ -14,6 +14,34 @@ return (static function () {
     $analyseCommand = new InvokableCommand('analyse', $container->get(AnalyseCommand::class), [
         new InputArgument('directory', InputArgument::OPTIONAL),
         new InputOption('config-path', 'c', InputOption::VALUE_OPTIONAL),
+        new InputOption(
+            'min-quality',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Minimal Quality level to reach without throw error',
+            0
+        ),
+        new InputOption(
+            'min-complexity',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Minimal Complexity level to reach without throw error',
+            0
+        ),
+        new InputOption(
+            'min-architecture',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Minimal Architecture level to reach without throw error',
+            0
+        ),
+        new InputOption(
+            'min-style',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Minimal Style level to reach without throw error',
+            0
+        ),
     ]);
 
     return [

--- a/src/Application/Console/Analyser.php
+++ b/src/Application/Console/Analyser.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\PhpInsights\Application\Console;
 
 use NunoMaduro\PhpInsights\Domain\Insights\InsightCollectionFactory;
 use NunoMaduro\PhpInsights\Domain\MetricsFinder;
+use NunoMaduro\PhpInsights\Domain\Results;
 
 /**
  * @internal
@@ -34,9 +35,9 @@ final class Analyser
      * @param  array<string, array>  $config
      * @param  string  $dir
      *
-     * @return void
+     * @return  \NunoMaduro\PhpInsights\Domain\Results
      */
-    public function analyse(Style $style, array $config, string $dir): void
+    public function analyse(Style $style, array $config, string $dir): Results
     {
         $metrics = MetricsFinder::find();
 
@@ -51,5 +52,7 @@ final class Analyser
             ->misc($results);
 
         $style->issues($insightCollection, $metrics, $dir);
+
+        return $results;
     }
 }

--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -51,9 +51,9 @@ final class AnalyseCommand
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      *
-     * @return void
+     * @return int
      */
-    public function __invoke(InputInterface $input, OutputInterface $output): void
+    public function __invoke(InputInterface $input, OutputInterface $output): int
     {
         $style = new Style($input, OutputDecorator::decorate($output));
 
@@ -65,7 +65,30 @@ final class AnalyseCommand
             }
         }
 
-        $this->analyser->analyse($style, $this->getConfig($input, $directory), $directory);
+        $results = $this->analyser->analyse($style, $this->getConfig($input, $directory), $directory);
+
+        $hasError = false;
+        if ($input->getOption('min-quality') > $results->getCodeQuality()) {
+            $style->error('The Code quality level is too low');
+            $hasError = true;
+        }
+
+        if ($input->getOption('min-complexity') > $results->getComplexity()) {
+            $style->error('The Complexity level is too low');
+            $hasError = true;
+        }
+
+        if ($input->getOption('min-architecture') > $results->getStructure()) {
+            $style->error('The Architecture level is too low');
+            $hasError = true;
+        }
+
+        if ($input->getOption('min-style') > $results->getStructure()) {
+            $style->error('The Architecture level is too low');
+            $hasError = true;
+        }
+
+        return (int) $hasError;
     }
 
     /**

--- a/src/Application/Console/Commands/InvokableCommand.php
+++ b/src/Application/Console/Commands/InvokableCommand.php
@@ -36,8 +36,6 @@ final class InvokableCommand extends BaseCommand
      */
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        call_user_func($this->callable, $input, $output);
-
-        return 0;
+        return call_user_func($this->callable, $input, $output);
     }
 }


### PR DESCRIPTION
Refs #60 , implements exit status code and min levels to reach.

```bash
 $ php bin/phpinsights --help                               
Usage:
  analyse [options] [--] [<directory>]

Arguments:
  directory                                  

Options:
  -c, --config-path[=CONFIG-PATH]            
      --min-quality[=MIN-QUALITY]            Minimal Quality level to reach without throw error [default: 0]
      --min-complexity[=MIN-COMPLEXITY]      Minimal Complexity level to reach without throw error [default: 0]
      --min-architecture[=MIN-ARCHITECTURE]  Minimal Architecture level to reach without throw error [default: 0]
      --min-style[=MIN-STYLE]                Minimal Style level to reach without throw error [default: 0]
  -h, --help                                 Display this help message
  -q, --quiet                                Do not output any message
  -V, --version                              Display this application version
      --ansi                                 Force ANSI output
      --no-ansi                              Disable ANSI output
  -n, --no-interaction                       Do not ask any interactive question
  -v|vv|vvv, --verbose                       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

Tell me if I should add shortcut, or if information messages should be improved.
