### PR TITLE
Allow exclusion of files given a path

### DIFF
--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -56,6 +56,12 @@ final class LocalFilesRepository implements FilesRepository
         $this->finder->in([$directory])->exclude($exclude);
 
         foreach ($exclude as $value) {
+
+            if (mb_strpos($value, '/') !== false) {
+                $this->finder->notPath($value);
+                continue;
+            }
+
             if (substr($value, -4) === '.php') {
                 $this->finder->notName($value);
             }


### PR DESCRIPTION
Allows to exclude files/directories with their relative path.
Example:
```
'exclude' => [
    'app/Models/User.php',
    'app/Services/MyService',
]
```
Useful if you have classes with the same name in different namespaces.