### PR TITLE
Require necessary extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
+        "ext-iconv": "*",
         "league/container": "^3.2",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
         "phploc/phploc": "^5.0",


### PR DESCRIPTION
Addresses #72. nette/utils doesn't explicit require it because they provide too many things, but they do suggest it (https://github.com/nette/utils/blob/master/composer.json#L25). Since it's part of the core process of Insight to use `Strings::webalize`, it makes sense for Insights to require it on installation time instead of delegating to Runtime since Insights cannot work at all without it.