### PR TITLE
Add exclude key to default stub

### DIFF
--- a/stubs/config.php
+++ b/stubs/config.php
@@ -30,6 +30,11 @@ return [
     |
     */
 
+    'exclude' => [
+        //  'path/to/directory-or-file'
+    ],
+
+
     'add' => [
         //  ExampleMetric::class => [
         //      ExampleInsight::class,

--- a/stubs/laravel.php
+++ b/stubs/laravel.php
@@ -41,6 +41,10 @@ return [
     |
     */
 
+    'exclude' => [
+        //  'path/to/directory-or-file'
+    ],
+
     'add' => [
         Classes::class => [
             ForbiddenFinalClasses::class,

--- a/stubs/symfony.php
+++ b/stubs/symfony.php
@@ -29,6 +29,10 @@ return [
     | mind, that all added `Insights` must belong to a specific `Metric`.
     |
     */
+    
+    'exclude' => [
+        //  'DirectoryOrFileToExclude'
+    ],
 
     'add' => [
         //  ExampleMetric::class => [

--- a/stubs/symfony.php
+++ b/stubs/symfony.php
@@ -31,7 +31,7 @@ return [
     */
     
     'exclude' => [
-        //  'DirectoryOrFileToExclude'
+        //  'path/to/directory-or-file'
     ],
 
     'add' => [


### PR DESCRIPTION
This will help people to know how to exclude certain files / directories. Eg. within Symfony people usually want to exclude `src/Migrations` directory totally just because it contains generated files.