### PR TITLE
Add --ansi option to insights script in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",
-        "insights": "bin/phpinsights analyse -v --no-interaction --min-quality=85.7 --min-complexity=73.7 --min-architecture=77.3 --min-style=89.1",
+        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-complexity=73.7 --min-architecture=77.3 --min-style=89.1",
         "test": [
             "@phpstan:test",
             "@ecs:test",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | no
| Improvment?   | yes
| Fixed tickets | N/A

As others script ran by Composer, I add the `--ansi` option to insight to get colors in travis build output.