### PR TITLE
Add exit status code error when detect Security Issues

### DIFF
--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -88,6 +88,10 @@ final class AnalyseCommand
             $hasError = true;
         }
 
+        if ($results->getTotalSecurityIssues() > 0) {
+            $hasError = true;
+        }
+
         $style->newLine();
         $style->writeln('✨ See something that needs to be improved? <bold>Create an issue</> or send us a <bold>pull request</>: <title>https://github.com/nunomaduro/phpinsights</title>');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | N/A

I think when security issues are detected, we should in every case return an exit error code 
