### PR TITLE
Fix issue with overwrite of existing preset config options

### DIFF
--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -39,7 +39,7 @@ final class ConfigResolver
 
         foreach (self::$presets as $presetClass) {
             if ($presetClass::getName() === $preset) {
-                $config = array_merge_recursive($presetClass::get(), $config);
+                $config = array_replace_recursive($presetClass::get(), $config);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

Currently it's not possible to overwrite an existing config from the preset. The following example will produce the following error:
```php
<?php declare(strict_types=1);

use SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff;

return [
    'preset' => 'default',
    'config' => [
        DeclareStrictTypesSniff::class => [
            'newlinesCountBetweenOpenTagAndDeclare' => 0,
        ],
    ],
];
```

`
PHP Notice:  Array to string conversion in <path>/phpinsights/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/SniffSettingsHelper.php on line 21
`
The reason for this problem is that `array_merge_recursive` merges two values into an array instead of replacing it. `array_replace_recursive` will replace the setting instead of creating an array out of the two values `1` and `0`.

Test code:
```php
<?php declare(strict_types=1);

$config = [
    \SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff::class => [
        'newlinesCountBetweenOpenTagAndDeclare' => 0,
    ],
];
print_r(array_merge_recursive(\NunoMaduro\PhpInsights\Application\DefaultPreset::get()['config'], $config));
print_r(array_replace_recursive(\NunoMaduro\PhpInsights\Application\DefaultPreset::get()['config'], $config));
```

Expeceted after the fix:
```
Array
(
    [SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff] => Array
        (
            [linesCountBetweenDifferentAnnotationsTypes] => 1
        )

    [SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff] => Array
        (
            [newlinesCountBetweenOpenTagAndDeclare] => 0
            [spacesCountAroundEqualsSign] => 0
        )

)
```

Actual:
```
Array
(
    [SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff] => Array
        (
            [linesCountBetweenDifferentAnnotationsTypes] => 1
        )

    [SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff] => Array
        (
            [newlinesCountBetweenOpenTagAndDeclare] => Array
                (
                    [0] => 2
                    [1] => 0
                )

            [spacesCountAroundEqualsSign] => 0
        )

)
```