### PR TITLE
Add option to disable security issues check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,12 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - composer run test
+  - |
+    if [[ -z $COMPOSER_FLAGS ]]; then
+      composer run test
+    else
+      composer run phpstan:test
+      composer run ecs:test
+      composer run phpunit:test
+      composer run insights -- --disable-security-check
+    fi

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",
-        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-architecture=77.3 --min-style=89.1",
+        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-architecture=77.3 --min-style=89.1 --disable-security-check",
         "test": [
             "@phpstan:test",
             "@ecs:test",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",
-        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-architecture=77.3 --min-style=89.1 --disable-security-check",
+        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-architecture=77.3 --min-style=89.1",
         "test": [
             "@phpstan:test",
             "@ecs:test",

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -14,3 +14,16 @@ php artisan insights --no-interaction --min-quality=80 --min-complexity=90 --min
 **Note**: The `--no-interaction` option is mandatory when it's launch in CI to avoid prompts.
 
 All others are optional, so if you want to focus only on style, add the `--min-style` and forget others.
+
+## Disable Security Check
+
+In case you develop a library or a plugin, it could be compatible with a large panel of dependencies versions.
+So you can launch your `composer update` with `--prefer-lower` flag to tests theses minimum version.
+
+As `phpinsights` return an exit error code if security issues are found, you can disable this check by adding the `--disable-security-check` option :
+
+```bash
+./vendor/bin/phpinsights --no-interaction --disable-security-check
+```
+
+**Note** : For a project inspection, you **should** never use this option to keep your project safe.

--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -88,7 +88,7 @@ final class AnalyseCommand
             $hasError = true;
         }
 
-        if ($results->getTotalSecurityIssues() > 0) {
+        if (! (bool) $input->getOption('disable-security-check') && $results->getTotalSecurityIssues() > 0) {
             $hasError = true;
         }
 

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -57,6 +57,12 @@ final class AnalyseDefinition
                 'Minimal Style level to reach without throw error',
                 0
             ),
+            new InputOption(
+                'disable-security-check',
+                null,
+                InputOption::VALUE_NONE,
+                'Disable Security issues check to not throw error if vulnerability is found'
+            )
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | see PR #106

Add `--disable-security-check` to bypass exit error code introduced in #106 when vulnerability is detected.