### PR TITLE
Make Contributions easier by having an online IDE (Gitpod)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+- init: composer install

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ composer require nunomaduro/phpinsights --dev
 - Designed to work out-of-the-box with **Laravel**, **Symfony**, **Yii**, **Magento**, and more
 - Contains built-in checks for making code reliable, loosely coupled, **simple**, and **clean**
 
+## 🛠 Contribute
+
+Contributions are welcome, and are accepted via pull requests. Please review these [guidelines](CONTRIBUTING.md) before submitting any pull requests.
+
+A quick way to browse, modify and run the source code is to open it in Gitpod (an online IDE):
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nunomaduro/phpinsights)
+
 ## 💖 Support the development
 **Do you like this project? Support it by donating**
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

hi there 👋! 

thank you for helping to keep the code quality of many projects at high standards. 

I thought to help the community to contribute back their knowledge about best practices, I could be helpful to have an online IDE ([gitpod.io](gitpod.io)). That's a quick and convenient way for potential contributors to browse, modify and run the source code. Modifications can be submitted back to this project as PRs. Gitpod has full language support for PHP. In fact, it uses the same language server as VS Code.

To try, click here:
https://gitpod.io/#https://github.com/meysholdt/phpinsights

This will
1. launch a new workspace based on a docker image
2. git-clone this repository (GitHub OAuth needed)
3. run `composer install`.
4. If you enter `composer test` in the terminal, the tests will run and pass. 

This is how it looks like:

![image](https://user-images.githubusercontent.com/239422/58021316-da11cd80-7b0a-11e9-95e2-e4e9dbf87697.png)

This PR:
- adds a config file to let Gitpod run `composer install` after opening a workspace.
- adds a link to the README to tell potential contributors about this possibility.

Disclosure: I work on Gitpod.

Let me know if this is something you find useful.
