### PR TITLE
Fix create EcsContainer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/clean-code.yml",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",
-        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-architecture=77.3 --min-style=89.1",
+        "insights": "bin/phpinsights analyse --ansi -v --no-interaction --min-quality=85.7 --min-architecture=76.2 --min-style=89.1",
         "test": [
             "@phpstan:test",
             "@ecs:test",

--- a/src/Domain/EcsContainer.php
+++ b/src/Domain/EcsContainer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain;
 
 use Symfony\Component\DependencyInjection\Container;
+use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
+use Symplify\PackageBuilder\Console\Input\InputDetector;
 
 /**
  * @internal
@@ -22,13 +24,10 @@ final class EcsContainer
     public static function make(): Container
     {
         if (self::$container === null) {
-            if (file_exists(__DIR__ . '/../../vendor/symplify/easy-coding-standard/bin/container.php')) {
-                $containerPath = __DIR__ . '/../../vendor/symplify/easy-coding-standard/bin/container.php';
-            } else {
-                $containerPath = __DIR__ . '/../../../../symplify/easy-coding-standard/bin/container.php';
-            }
+            $easyCodingStandardKernel = new EasyCodingStandardKernel('phpinsights', InputDetector::isDebug());
+            $easyCodingStandardKernel->boot();
 
-            self::$container = require $containerPath;
+            self::$container = $easyCodingStandardKernel->getContainer();
         }
 
         return self::$container;

--- a/src/Domain/EcsContainer.php
+++ b/src/Domain/EcsContainer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain;
 
-use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
 use Symplify\PackageBuilder\Console\Input\InputDetector;
 
@@ -14,18 +14,20 @@ use Symplify\PackageBuilder\Console\Input\InputDetector;
 final class EcsContainer
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\Container
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
      */
     private static $container;
 
-    /**
-     * @return \Symfony\Component\DependencyInjection\Container
-     */
-    public static function make(): Container
+
+    public static function make(): ContainerInterface
     {
         if (self::$container === null) {
             $easyCodingStandardKernel = new EasyCodingStandardKernel('phpinsights', InputDetector::isDebug());
             $easyCodingStandardKernel->boot();
+
+            if ($easyCodingStandardKernel->getContainer() === null) {
+                throw new \RuntimeException('Unable to get EcsContainer');
+            }
 
             self::$container = $easyCodingStandardKernel->getContainer();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #123 

Refs @TomasVotruba response (https://github.com/nunomaduro/phpinsights/issues/123#issuecomment-494683841) I change the way to create EcsContainer to avoid bug using shortcut for config-path.
