### PR TITLE
Add GitHub link to the VuePress navbar

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,7 @@ module.exports = {
   description: 'The perfect starting point to analyze the code quality of your PHP projects',
   sidebar: true,
   themeConfig: {
+    repo: 'nunomaduro/phpinsights',
     sidebar: [
       '/get-started',
       '/configuration',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This adds a link to the GitHub repository from the navigation bar of the VuePress site.

![VuePress Navigation Example](https://image.prntscr.com/image/B6DVQi53REGDz0ZmKDPQhQ.png)
