### PR TITLE
[Fix] Custom config overrides preset values instead of merging them

### DIFF
--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -41,7 +41,7 @@ final class ConfigResolver
 
         foreach (self::$presets as $presetClass) {
             if ($presetClass::getName() === $preset && is_array($config)) {
-                $config = array_merge_recursive($presetClass::get(), $config);
+                $config = array_merge_recursive($config, $presetClass::get());
             }
         }
 

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -41,7 +41,7 @@ final class ConfigResolver
 
         foreach (self::$presets as $presetClass) {
             if ($presetClass::getName() === $preset && is_array($config)) {
-                $config = array_merge_recursive($config, $presetClass::get());
+                $config = array_replace_recursive($config, $presetClass::get());
             }
         }
 

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -41,7 +41,7 @@ final class ConfigResolver
 
         foreach (self::$presets as $presetClass) {
             if ($presetClass::getName() === $preset && is_array($config)) {
-                $config = array_replace_recursive($presetClass::get(), $config);
+                $config = array_merge_recursive($presetClass::get(), $config);
             }
         }
 

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -41,7 +41,7 @@ final class ConfigResolver
 
         foreach (self::$presets as $presetClass) {
             if ($presetClass::getName() === $preset && is_array($config)) {
-                $config = array_replace_recursive($config, $presetClass::get());
+                $config = array_merge_recursive($config, $presetClass::get());
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #143 #145 

When having a custom `exclude` array, the values from the preset are overridden.
This change will do so the config file has highest priority, and then the preset file when merging them instead of replacing the value.

resolves: #143, #145