### PR TITLE
Fixes the configuration extending.

### DIFF
--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -41,7 +41,7 @@ final class ConfigResolver
 
         foreach (self::$presets as $presetClass) {
             if ($presetClass::getName() === $preset && is_array($config)) {
-                $config = array_replace_recursive($presetClass::get(), $config);
+                $config = array_merge_recursive($presetClass::get(), $config);
             }
         }
 

--- a/tests/Application/LaravelConfigExtendingTest.php
+++ b/tests/Application/LaravelConfigExtendingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application;
+
+use NunoMaduro\PhpInsights\Application\Adapters\Laravel\Preset;
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineGlobalConstants;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenPrivateMethods;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
+use PHPUnit\Framework\TestCase;
+
+final class LaravelConfigExtendingTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    private $laravelPresetConfig;
+
+    /**
+     * @var array
+     */
+    private $configExtending;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->laravelPresetConfig = Preset::get();
+        $this->configExtending = require __DIR__ . '/../Fixtures/ConfigFiles/Laravel/config-extending.php';
+    }
+
+    public function testExtendingConfigKey_Exclude(): void
+    {
+        $excludeCountOnPreset = count($this->laravelPresetConfig['exclude']);
+        $excludeCountOnExtending = count($this->configExtending['exclude']);
+        $finalConfig = ConfigResolver::resolve($this->configExtending, '');
+
+        $this->assertEquals(11, $excludeCountOnPreset);
+        $this->assertEquals(3, $excludeCountOnExtending);
+        $this->assertCount($excludeCountOnPreset + $excludeCountOnExtending, $finalConfig['exclude']);
+    }
+
+    public function testExtendingConfigKey_Add(): void
+    {
+        $addCountOnPreset = count($this->laravelPresetConfig['add']);
+        $addCountOnExtending = count($this->configExtending['add']);
+        $finalConfig = ConfigResolver::resolve($this->configExtending, '');
+
+        $this->assertEquals(0, $addCountOnPreset);
+        $this->assertEquals(1, $addCountOnExtending);
+        $this->assertCount($addCountOnPreset + $addCountOnExtending, $finalConfig['add']);
+    }
+
+    public function testExtendingConfigKey_Remove(): void
+    {
+        $removeCountOnPreset = count($this->laravelPresetConfig['remove']);
+        $removeCountOnExtending = count($this->configExtending['remove']);
+        $finalConfig = ConfigResolver::resolve($this->configExtending, '');
+
+        $this->assertEquals(0, $removeCountOnPreset);
+        $this->assertEquals(7, $removeCountOnExtending);
+        $this->assertCount($removeCountOnPreset + $removeCountOnExtending, $finalConfig['remove']);
+    }
+
+    public function testExtendingConfigKey_Config(): void
+    {
+        $configCountOnPreset = count($this->laravelPresetConfig['config']);
+        $configCountOnExtending = count($this->configExtending['config']);
+        $finalConfig = ConfigResolver::resolve($this->configExtending, '');
+
+        $this->assertEquals(2, $configCountOnPreset);
+        $this->assertEquals(1, $configCountOnExtending);
+        $this->assertCount($configCountOnPreset + $configCountOnExtending, $finalConfig['config']);
+
+        $this->assertArrayHasKey(ForbiddenDefineGlobalConstants::class, $finalConfig['config']);
+        $this->assertArrayHasKey(ForbiddenFunctionsSniff::class, $finalConfig['config']);
+        $this->assertArrayHasKey(ForbiddenPrivateMethods::class, $finalConfig['config']);
+    }
+}

--- a/tests/Fixtures/ConfigFiles/Laravel/config-extending.php
+++ b/tests/Fixtures/ConfigFiles/Laravel/config-extending.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineFunctions;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenFinalClasses;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenNormalClasses;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenPrivateMethods;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenTraits;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Classes;
+use SlevomatCodingStandard\Sniffs\Namespaces\AlphabeticallySortedUsesSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Preset
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default preset that will be used by PHP Insights
+    | to make your code reliable, simple, and clean. However, you can always
+    | adjust the `Metrics` and `Insights` below in this configuration file.
+    |
+    | Supported: "default", "laravel", "symfony", "magento2", "drupal"
+    |
+    */
+
+    'preset' => 'laravel',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may adjust all the various `Insights` that will be used by PHP
+    | Insights. You can either add, remove or configure `Insights`. Keep in
+    | mind that all added `Insights` must belong to a specific `Metric`.
+    |
+    */
+
+    'exclude' => [
+          'path/to/directory-or-file-1',
+          'path/to/directory-or-file-2',
+          'path/to/directory-or-file-3',
+    ],
+
+    'add' => [
+        Classes::class => [
+            ForbiddenFinalClasses::class,
+        ],
+    ],
+
+    'remove' => [
+        AlphabeticallySortedUsesSniff::class,
+        DeclareStrictTypesSniff::class,
+        DisallowMixedTypeHintSniff::class,
+        ForbiddenDefineFunctions::class,
+        ForbiddenNormalClasses::class,
+        ForbiddenTraits::class,
+        TypeHintDeclarationSniff::class,
+    ],
+
+    'config' => [
+        ForbiddenPrivateMethods::class => [
+            'title' => 'The usage of private methods is not idiomatic in Laravel.',
+        ],
+    ],
+
+];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Fixed tickets | #145 

In a Laravel App,

When adding paths on config/insights.php -> exclude key

It turns out is not merging, but replacing, taking to erroneous behaviour.

Added tests accordingly, for all keys in config: `exclude`, `add`, `remove`, and `config`
