### PR TITLE
Fix incorrect cyclomatic complexity calculation (#134)

### DIFF
--- a/src/Domain/Analyser.php
+++ b/src/Domain/Analyser.php
@@ -102,6 +102,10 @@ final class Analyser
 
                     $collector->incrementLogicalLines();
                 } else if ($token === '?') {
+                    if($currentBlock === \T_FUNCTION) {
+                        continue;
+                    }
+                    
                     if ($className !== null) {
                         $collector->currentClassIncrementComplexity();
                         $collector->currentMethodIncrementComplexity();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #134 

This PR fixes incorrect calculation of cyclomatic complexity when using type hint in arguments and return value in functions declaration