### PR TITLE
Remove useless checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,6 @@
         "phpstan:test": "Run the phpstan tests.",
         "phpunit:test": "Run the phpunit tests.",
         "insights": "Run the phpinsights tests",
-        "test": "Run all tests including phpstan, phpunit and ecs."
+        "test": "Run all tests including phpstan, ecs, phpunit, and insights."
     }
 }

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -40,12 +40,12 @@ final class ConfigResolver
         $preset = $config['preset'] ?? self::guess($directory);
 
         foreach (self::$presets as $presetClass) {
-            if ($presetClass::getName() === $preset && is_array($config)) {
+            if ($presetClass::getName() === $preset) {
                 $config = array_replace_recursive($presetClass::get(), $config);
             }
         }
 
-        return is_array($config) ? $config : [];
+        return $config;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | ...

The `$config` parameter of `ConfigResolver::resolve()` method is exactly an array, so we don't need to add 2 `is_array` checks here.
