### PR TITLE
Update sensiolabs/security-checker requirement from ^5.0 to ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "league/container": "^3.2",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
         "phploc/phploc": "^5.0",
-        "sensiolabs/security-checker": "^5.0",
+        "sensiolabs/security-checker": "^6.0",
         "symfony/console": "^4.2",
         "symfony/finder": "^4.2",
         "symplify/coding-standard": "^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no

Just updates the security-checker from sensiolabs reported by the dependabot.
