### PR TITLE
Update localheinz/phpstan-rules requirement from ^0.6.0 to ^0.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "illuminate/console": "^5.8",
         "illuminate/support": "^5.8",
-        "localheinz/phpstan-rules": "^0.6.0",
+        "localheinz/phpstan-rules": "^0.10.0",
         "phpstan/phpstan-strict-rules": "^0.11",
         "roave/no-floaters": "^1.1",
         "phpstan/phpstan": "^0.11.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no

Just updates the phpstan-rule from localheinz reported by the dependabot.

I haven't seen any significant changes. I have only seen fixes and the addition of new rules. https://github.com/localheinz/phpstan-rules/compare/0.6.0...0.10.0