### PR TITLE
Display InsightClass also when Insight has no detail

### DIFF
--- a/src/Application/Console/Style.php
+++ b/src/Application/Console/Style.php
@@ -225,7 +225,7 @@ EOD;
 
                 $issue = "\n<fg=red>•</> [$category] <bold>{$insight->getTitle()}</bold>";
 
-                if (! $insight instanceof HasDetails) {
+                if (! $insight instanceof HasDetails && ! $this->output->isVerbose()) {
                     $this->writeln($issue);
                     continue;
                 }
@@ -233,6 +233,12 @@ EOD;
                 if ($this->output->isVerbose()) {
                     $issue .= " ({$insight->getInsightClass()})";
                 }
+
+                if (! $insight instanceof HasDetails) {
+                    $this->writeln($issue);
+                    continue;
+                }
+
                 $details = $insight->getDetails();
                 $totalDetails = count($details);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

When an Insight doesn't implement HasDetail, we cannot see it's Class with `-v` option.

```
// example
• [Architecture] Property per class limit: (ObjectCalisthenics\Sniffs\Metrics\PropertyPerClassLimitSniff)
  src/Domain/Collector.php:13: "class" has too many properties: 40. Can be up to 10 properties.

• [Architecture] The name property in the `composer.json` contains the default value
```

This fix allow that 

```
• [Architecture] Property per class limit: (ObjectCalisthenics\Sniffs\Metrics\PropertyPerClassLimitSniff)
  src/Domain/Collector.php:13: "class" has too many properties: 40. Can be up to 10 properties.

• [Architecture] The name property in the `composer.json` contains the default value: (NunoMaduro\PhpInsights\Domain\Insights\ComposerMustContainName)
```

