### PR TITLE
[Fix] Fixed the usage of two unused parameter sniffs

### DIFF
--- a/docs/insights/code.md
+++ b/docs/insights/code.md
@@ -305,12 +305,6 @@ This sniff looks for unused inherited variables passed to closure via `use`.
 
 **Insight Class**: `SlevomatCodingStandard\Sniffs\Functions\UnusedInheritedVariablePassedToClosureSniff`
 
-## Unused parameter <Badge text="^1.0"/> <Badge text="Code\Code" type="warn"/>
-
-This sniff looks for unused parameters.
-
-**Insight Class**: `SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff`
-
 ## Useless Parameter default value <Badge text="^1.0"/> <Badge text="Code\Code" type="warn"/>
 
 This sniff looks for useless parameter default value.
@@ -492,13 +486,11 @@ This sniff reports documentation comments containing only `{@inheritDoc}` annota
 
 **Insight Class**: `SlevomatCodingStandard\Sniffs\Commenting\UselessInheritDocCommentSniff`
 
-## Unused function parameter <Badge text="^1.0"/> <Badge text="Code\Functions" type="warn"/>
+## Unused parameter <Badge text="^1.0"/> <Badge text="Code\Functions" type="warn"/>
 
-This sniff checks that all function parameters are used in the function body.
-One exception is made for empty function bodies or function bodies that only contain comments.
-This could be useful for the classes that implement an interface that defines multiple methods but the implementation only needs some of them.
+This sniff looks for unused parameters.
 
-**Insight Class**: `PHP_CodeSniffer\Standards\Generic\Sniffs\UnusedFunctionParameterSniff`
+**Insight Class**: `SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff`
 
 ## Call time pass by reference <Badge text="^1.0"/> <Badge text="Code\Functions" type="warn"/>
 

--- a/src/Domain/Metrics/Code/Code.php
+++ b/src/Domain/Metrics/Code/Code.php
@@ -37,7 +37,6 @@ use SlevomatCodingStandard\Sniffs\ControlStructures\DisallowYodaComparisonSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\LanguageConstructWithParenthesesSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\DeadCatchSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UnusedInheritedVariablePassedToClosureSniff;
-use SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UselessParameterDefaultValueSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UseFromSameNamespaceSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UselessAliasSniff;
@@ -98,7 +97,6 @@ final class Code implements HasValue, HasInsights
             LanguageConstructWithParenthesesSniff::class,
             DeadCatchSniff::class,
             UnusedInheritedVariablePassedToClosureSniff::class,
-            UnusedParameterSniff::class,
             UselessParameterDefaultValueSniff::class,
             UseFromSameNamespaceSniff::class,
             UselessAliasSniff::class,

--- a/src/Domain/Metrics/Code/Functions.php
+++ b/src/Domain/Metrics/Code/Functions.php
@@ -10,13 +10,13 @@ use NunoMaduro\PhpInsights\Domain\Contracts\HasInsights;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasPercentage;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasValue;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineFunctions;
-use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnusedFunctionParameterSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\CallTimePassByReferenceSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 use PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UnusedInheritedVariablePassedToClosureSniff;
+use SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff;
 
 final class Functions implements HasValue, HasPercentage, HasAvg, HasInsights
 {
@@ -42,7 +42,7 @@ final class Functions implements HasValue, HasPercentage, HasAvg, HasInsights
     {
         return [
             UnusedInheritedVariablePassedToClosureSniff::class,
-            UnusedFunctionParameterSniff::class,
+            UnusedParameterSniff::class,
             CallTimePassByReferenceSniff::class,
             DeprecatedFunctionsSniff::class,
             NullableTypeDeclarationSniff::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Fixed tickets | #177 

There are two different unused parameter sniffs in our code. 
This PR removes one of them so we don't get double reports of the same error.


resolves: #177 