### PR TITLE
Improves ignore path on specific sniff

### DIFF
--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -94,7 +94,7 @@ To know the className of an Insights, launch `phpinsights` with `-v` option (ver
 
 The `config` section allows you to refine default insight configuration.
 
-For example, to increase the line lenght limits:
+For example, to increase the line length limits:
 ```php
     'config' => [
         \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff::class => [
@@ -103,3 +103,6 @@ For example, to increase the line lenght limits:
         ]
     ]
 ```
+
+You can also configure the `exclude` parameter on each insight, to disallow a
+insight on a specific file.

--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain;
 
-use NunoMaduro\PhpInsights\Domain\Sniffs\SniffWrapper;
+use NunoMaduro\PhpInsights\Domain\Sniffs\SniffDecorator;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File as BaseFile;
 use PHP_CodeSniffer\Fixer;
@@ -28,7 +28,7 @@ final class File extends BaseFile
     private $previousActiveSniffClass;
 
     /**
-     * @var array<array<\NunoMaduro\PhpInsights\Domain\Sniffs\SniffWrapper>>
+     * @var array<array<\NunoMaduro\PhpInsights\Domain\Sniffs\SniffDecorator>>
      */
     private $tokenListeners = [];
 
@@ -145,7 +145,7 @@ final class File extends BaseFile
     }
 
     /**
-     * @param array<array<\NunoMaduro\PhpInsights\Domain\Sniffs\SniffWrapper>> $tokenListeners
+     * @param array<array<\NunoMaduro\PhpInsights\Domain\Sniffs\SniffDecorator>> $tokenListeners
      */
     public function processWithTokenListenersAndFileInfo(array $tokenListeners, SmartFileInfo $fileInfo): void
     {
@@ -191,12 +191,12 @@ final class File extends BaseFile
     }
 
     /**
-     * @param SniffWrapper $sniff
+     * @param SniffDecorator $sniff
      */
-    private function reportActiveSniffClass(SniffWrapper $sniff): void
+    private function reportActiveSniffClass(SniffDecorator $sniff): void
     {
         // used in other places later
-        $this->activeSniffClass = get_class($sniff->getWrappedSniff());
+        $this->activeSniffClass = get_class($sniff->getSniff());
 
         if (! $this->easyCodingStandardStyle->isDebug()) {
             return;

--- a/src/Domain/FileProcessor.php
+++ b/src/Domain/FileProcessor.php
@@ -20,7 +20,7 @@ final class FileProcessor implements FileProcessorInterface
     private $sniffs = [];
 
     /**
-     * @var array<array<\NunoMaduro\PhpInsights\Domain\Sniffs\SniffWrapper>>
+     * @var array<array<\NunoMaduro\PhpInsights\Domain\Sniffs\SniffDecorator>>
      */
     private $tokenListeners = [];
 

--- a/src/Domain/Insights/InsightFactory.php
+++ b/src/Domain/Insights/InsightFactory.php
@@ -9,7 +9,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
 use NunoMaduro\PhpInsights\Domain\EcsContainer;
 use NunoMaduro\PhpInsights\Domain\FileProcessor;
 use NunoMaduro\PhpInsights\Domain\Reflection;
-use NunoMaduro\PhpInsights\Domain\Sniffs\SniffWrapper;
+use NunoMaduro\PhpInsights\Domain\Sniffs\SniffDecorator;
 use PHP_CodeSniffer\Sniffs\Sniff as SniffContract;
 use Symplify\EasyCodingStandard\Application\EasyCodingStandardApplication;
 use Symplify\EasyCodingStandard\Configuration\Configuration;
@@ -47,7 +47,7 @@ final class InsightFactory
      *
      * @param  \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository  $filesRepository
      * @param  string  $dir
-     * @param array<string> $insightsClasses
+     * @param  array<string>  $insightsClasses
      */
     public function __construct(FilesRepository $filesRepository, string $dir, array $insightsClasses)
     {
@@ -80,7 +80,7 @@ final class InsightFactory
     /**
      * Returns the Sniffs PHP CS classes from the given array of Metrics.
      *
-     * @param array<string> $insights
+     * @param  array<string>  $insights
      * @param  array<string, array>  $config
      *
      * @return array<\PHP_CodeSniffer\Sniffs\Sniff>
@@ -174,7 +174,7 @@ final class InsightFactory
 
         $sniffer = Container::make()->get(FileProcessor::class);
         foreach ($this->sniffsFrom($this->insightsClasses, $config) as $sniff) {
-            $sniffer->addSniff(new SniffWrapper($sniff));
+            $sniffer->addSniff(new SniffDecorator($sniff, $this->dir));
         }
 
         /** @var \Symplify\EasyCodingStandard\Application\EasyCodingStandardApplication $application */

--- a/src/Domain/Sniffs/SniffDecorator.php
+++ b/src/Domain/Sniffs/SniffDecorator.php
@@ -9,19 +9,24 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * This class allows us to wrap original
- * phpcs sniffs adding custom logic into it.
+ * Decorates original php-cs sniffs with additional behavior.
  */
-final class SniffWrapper implements Sniff
+final class SniffDecorator implements Sniff
 {
     /**
      * @var \PHP_CodeSniffer\Sniffs\Sniff
      */
     private $sniff;
 
-    public function __construct(Sniff $sniff)
+    /**
+     * @var string
+     */
+    private $dir;
+
+    public function __construct(Sniff $sniff, string $dir)
     {
         $this->sniff = $sniff;
+        $this->dir = $dir;
     }
 
     public function register(): array
@@ -47,7 +52,7 @@ final class SniffWrapper implements Sniff
         }
 
         foreach ($this->getIgnoredFilesPath() as $ignoredFilePath) {
-            if (self::pathsAreEqual($ignoredFilePath, $path)) {
+            if (self::pathsAreEqual($this->dir . DIRECTORY_SEPARATOR . $ignoredFilePath, $path)) {
                 return true;
             }
         }
@@ -62,7 +67,7 @@ final class SniffWrapper implements Sniff
      */
     private function getIgnoredFilesPath(): array
     {
-        return $this->sniff->ignoreFiles ?? [];
+        return $this->sniff->exclude ?? [];
     }
 
     private static function pathsAreEqual(string $pathA, string $pathB): bool
@@ -70,10 +75,7 @@ final class SniffWrapper implements Sniff
         return realpath($pathA) === realpath($pathB);
     }
 
-    /**
-     * Returns the sniff which we have wrapped.
-     */
-    public function getWrappedSniff(): Sniff
+    public function getSniff(): Sniff
     {
         return $this->sniff;
     }

--- a/tests/Domain/Sniffs/SniffDecoratorTest.php
+++ b/tests/Domain/Sniffs/SniffDecoratorTest.php
@@ -8,15 +8,15 @@ use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Classes;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\OneClassPerFileSniff;
 use Tests\TestCase;
 
-final class SniffWrapperTest extends TestCase
+final class SniffDecoratorTest extends TestCase
 {
-    public function testCanIgnoreFileInSniffWithRelativePath(): void
+    public function testCanIgnoreFileInSniffWithFullPath(): void
     {
        $collection = $this->runAnalyserOnConfig(
            [
                'config' => [
                    OneClassPerFileSniff::class => [
-                       'ignoreFiles' => [
+                       'exclude' => [
                            __DIR__ . '/../../Fixtures/Domain/Sniffs/SniffWrapper/FileWithTwoClasses.php'
                        ]
                    ]
@@ -39,6 +39,38 @@ final class SniffWrapperTest extends TestCase
 
        // No errors of this type as we are ignoring the file.
        self::assertEquals(0, $oneClassPerFileSniffErrors);
+    }
+
+    public function testCanIgnoreFileInSniffWithRelativePath(): void
+    {
+        $collection = $this->runAnalyserOnConfig(
+            [
+                'config' => [
+                    OneClassPerFileSniff::class => [
+                        'exclude' => [
+                            'Domain/Sniffs/SniffWrapper/FileWithTwoClasses.php'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                __DIR__ . '/../../Fixtures/Domain/Sniffs/SniffWrapper/FileWithTwoClasses.php'
+            ],
+            __DIR__ . '/../../Fixtures/'
+        );
+        $oneClassPerFileSniffErrors = 0;
+
+        foreach ($collection->allFrom(new Classes) as $insight) {
+            if (
+                $insight->hasIssue()
+                && $insight->getInsightClass() === OneClassPerFileSniff::class
+            ) {
+                $oneClassPerFileSniffErrors++;
+            }
+        }
+
+        // No errors of this type as we are ignoring the file.
+        self::assertEquals(0, $oneClassPerFileSniffErrors);
     }
 
     public function testFindMoreThanOneClassInFile(): void


### PR DESCRIPTION
Here is some modifications on the original pr to ignore paths on a specific sniff: https://github.com/nunomaduro/phpinsights/pull/182.

1. Renamed `ignoreFiles` to `exclude` to be consistence with the original `exclude` that exists on the config.
2. You can also pass now the relative path, example:

```php
    'config' => [
        DisallowMixedTypeHintSniff::class => [
            'exclude' => [
                'src/Domain/Reflection.php'
            ],
        ],
```

One think I don't like: This implementation is specific to phpcs instead of being something that can be applied to all insights. What do you guys think?