### PR TITLE
Remove mention of security issue when concerning insight is removed

### DIFF
--- a/src/Application/Console/Style.php
+++ b/src/Application/Console/Style.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Application\Console;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
 use NunoMaduro\PhpInsights\Domain\Insights\InsightCollection;
 use NunoMaduro\PhpInsights\Domain\Metrics\Architecture;
 use NunoMaduro\PhpInsights\Domain\Metrics\Code;
@@ -185,12 +186,19 @@ EOD;
     {
         $this->newLine();
 
-        $totalSecurityIssuesColor = $results->getTotalSecurityIssues() === 0 ? 'green' : 'red';
+        $message = sprintf(
+            '[MISC] %s on coding style',
+            "<fg={$this->getColor($results->getStyle())};options=bold>{$results->getStyle()} pts</>");
 
-        $this->writeln(sprintf("[MISC] %s on coding style and %s encountered",
-            "<fg={$this->getColor($results->getStyle())};options=bold>{$results->getStyle()} pts</>",
-            "<fg={$totalSecurityIssuesColor};options=bold>{$results->getTotalSecurityIssues()} security issues</>"
-        ));
+        if ($results->hasInsightInCategory(ForbiddenSecurityIssues::class, 'Security')) {
+            $totalSecurityIssuesColor = $results->getTotalSecurityIssues() === 0 ? 'green' : 'red';
+            $message .= sprintf(
+                ' and %s encountered',
+                "<fg={$totalSecurityIssuesColor};options=bold>{$results->getTotalSecurityIssues()} security issues</>"
+            );
+        }
+
+        $this->writeln($message);
 
         return $this;
     }

--- a/src/Domain/Exceptions/InsightClassNotFound.php
+++ b/src/Domain/Exceptions/InsightClassNotFound.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Domain\Exceptions;
+
+final class InsightClassNotFound extends \RuntimeException
+{
+}

--- a/tests/Domain/ResultsTest.php
+++ b/tests/Domain/ResultsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Domain;
 
 use NunoMaduro\PhpInsights\Domain\Collector;
+use NunoMaduro\PhpInsights\Domain\Exceptions\InsightClassNotFound;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
 use NunoMaduro\PhpInsights\Domain\Results;
 use PHPUnit\Framework\TestCase;
@@ -40,5 +41,30 @@ final class ResultsTest extends TestCase
         $results = new Results($collector, $categories);
 
         self::assertGreaterThan(0, $results->getTotalSecurityIssues());
+    }
+
+    public function testHasInsightClassInCategoryReturnFalse(): void
+    {
+        $collector = new Collector($this->baseFixturePath);
+        $categories = ['Security' => []];
+
+        $result = new Results($collector, $categories);
+        self::assertFalse($result->hasInsightInCategory(
+            ForbiddenSecurityIssues::class,
+            'Security'
+        ));
+    }
+
+    public function testHasInsightClassInCategoryReturnTrue(): void
+    {
+        $collector = new Collector($this->baseFixturePath);
+        $categories = [
+            'Security' => [new ForbiddenSecurityIssues($collector, [])]
+        ];
+        $result = new Results($collector, $categories);
+        self::assertTrue($result->hasInsightInCategory(
+            ForbiddenSecurityIssues::class,
+            'Security'
+        ));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #181 

This remove mention of security issues found when we remove ForbiddenSecurityIssues Insight.

I don't know if it's the better way. I'm not huge fan of the new public function hasInsightInCategory in Results, but I wanted to leave the function getTotalSecurityIssues returning 0 even if the Insight is removed to not alter the AnalyseCommand. 

WDYT ?
