### PR TITLE
[Docs] missing header + add concrete example for exclude file for Sniff

### DIFF
--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -104,5 +104,18 @@ For example, to increase the line length limits:
     ]
 ```
 
-You can also configure the `exclude` parameter on each insight, to disallow a
+You can also configure the `exclude` parameter on each insight, to disallow an
 insight on a specific file.
+
+For example, to remove "Unused Parameters" Insight only for some file:
+```php
+    'config' => [
+        \SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff::class => [
+            'exclude' => [
+                'src/Path/To/My/File.php',
+                'src/Path/To/Other/File.php,
+            ],
+        ]
+    ]
+```
+

--- a/docs/insights/architecture.md
+++ b/docs/insights/architecture.md
@@ -126,7 +126,7 @@ This insight disallow defining `globals`.
 
 **Insight Class**: `NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineGlobalConstants`
 
-##  <Badge text="^1.0"/> <Badge text="Architecture\Files" type="warn"/>
+## Superfluous Exception Naming <Badge text="^1.0"/> <Badge text="Architecture\Files" type="warn"/>
 
 This sniff reports use of superfluous prefix or suffix "Exception" for exceptions.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

While browsing the `architecture section` on docs, I noticed a missing header for superfluous exception naming.

I also add an example for configure the `exclude` Insight per file, especially for "Unused Parameter" Insight because I saw it in some issues.  
