### PR TITLE
Authorize analyse of one file or specific directory

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -35,6 +35,18 @@ You can also use `phpinsights` via Docker:
 docker run -it --rm -v $(pwd):/app nunomaduro/phpinsights
 ```
 
+## Analyse a sub-directory or a specific file
+
+You can ask `phpinsights` to analyse only a directory or even a specific file by providing path with `analyse` command:
+
+```bash
+# For a directory
+./vendor/bin/phpinsights analyse path/to/analyse
+
+# For a file
+./vendor/bin/phpinsights analyse path/to/analyse.php
+```
+
 ## Allowed memory size of X bytes exhausted
 
 If you encounter the error `Allowed memory size of XXXXX bytes exhausted`, the current workaround is to increase the memory limit:

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -47,6 +47,12 @@ You can ask `phpinsights` to analyse only a directory or even a specific file by
 ./vendor/bin/phpinsights analyse path/to/analyse.php
 ```
 
+In laravel, launch command as usual with your path:
+
+```bash
+php artisan insights path/to/analyse
+```
+
 ## Allowed memory size of X bytes exhausted
 
 If you encounter the error `Allowed memory size of XXXXX bytes exhausted`, the current workaround is to increase the memory limit:

--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -58,13 +58,19 @@ final class AnalyseCommand
 
         $directory = $this->getDirectory($input);
 
+        $isRootAnalyse = true;
         foreach (Kernel::getRequiredFiles() as $file) {
             if (! file_exists($directory . DIRECTORY_SEPARATOR . $file)) {
-                throw new \RuntimeException("The file `$file` must exist. You should run PHP Insights from the root of your project.");
+                $isRootAnalyse = false;
+                break;
             }
         }
+        $config = $this->getConfig($input, $directory);
 
-        $results = $this->analyser->analyse($style, $this->getConfig($input, $directory), $directory);
+        if (! $isRootAnalyse) {
+            $config = $this->excludeGlobalInsights($config);
+        }
+        $results = $this->analyser->analyse($style, $config, $directory);
 
         $hasError = false;
         if ($input->getOption('min-quality') > $results->getCodeQuality()) {
@@ -134,5 +140,19 @@ final class AnalyseCommand
         }
 
         return $directory;
+    }
+
+    /**
+     * @param array<string, array> $config
+     *
+     * @return array<string, array>
+     */
+    private function excludeGlobalInsights(array $config): array
+    {
+        foreach (Kernel::getGlobalInsights() as $insight) {
+            $config['remove'][] = $insight;
+        }
+
+        return $config;
     }
 }

--- a/src/Domain/Insights/InsightCollectionFactory.php
+++ b/src/Domain/Insights/InsightCollectionFactory.php
@@ -9,7 +9,6 @@ use NunoMaduro\PhpInsights\Domain\Contracts\HasInsights;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
 use NunoMaduro\PhpInsights\Domain\Exceptions\DirectoryNotFound;
-use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal
@@ -48,7 +47,7 @@ final class InsightCollectionFactory
     public function get(array $metrics, array $config, string $dir): InsightCollection
     {
         try {
-            $files = array_map(static function (SplFileInfo $file) {
+            $files = array_map(static function (\SplFileInfo $file) {
                 return $file->getRealPath();
             }, iterator_to_array($this->filesRepository->within($dir, $config['exclude'] ?? [])->getFiles()));
         } catch (\InvalidArgumentException $exception) {

--- a/src/Domain/Kernel.php
+++ b/src/Domain/Kernel.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain;
 
+use NunoMaduro\PhpInsights\Domain\Insights\Composer\ComposerLockMustBeFresh;
+use NunoMaduro\PhpInsights\Domain\Insights\Composer\ComposerMustBeValid;
+use NunoMaduro\PhpInsights\Domain\Insights\Composer\ComposerMustContainName;
+use NunoMaduro\PhpInsights\Domain\Insights\Composer\ComposerMustExist;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
+
 /**
  * @internal
  */
@@ -47,6 +53,22 @@ final class Kernel
             'composer.json',
             'composer.lock',
             // '.gitignore',
+        ];
+    }
+
+    /**
+     * Returns the list of Insights required on root.
+     *
+     * @return array<string>
+     */
+    public static function getGlobalInsights(): array
+    {
+        return [
+            ComposerMustBeValid::class,
+            ComposerLockMustBeFresh::class,
+            ComposerMustContainName::class,
+            ComposerMustExist::class,
+            ForbiddenSecurityIssues::class,
         ];
     }
 }

--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -51,6 +51,11 @@ final class LocalFilesRepository implements FilesRepository
      */
     public function within(string $directory, array $exclude = []): FilesRepository
     {
+        if (! is_dir($directory) && is_file($directory)) {
+            $this->finder->append([$directory]);
+
+            return $this;
+        }
         $this->finder->in([$directory])->notPath($exclude);
 
         foreach ($exclude as $value) {

--- a/tests/Infrastructure/Repositories/Fixtures/FileToInspect.php
+++ b/tests/Infrastructure/Repositories/Fixtures/FileToInspect.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+final class FileToInspect
+{
+}

--- a/tests/Infrastructure/Repositories/LocalFilesRepositoryTest.php
+++ b/tests/Infrastructure/Repositories/LocalFilesRepositoryTest.php
@@ -24,4 +24,17 @@ final class LocalFilesRepositoryTest extends TestCase
 
         self::assertEmpty($files);
     }
+
+    public function testPassFileInsteadOfDirectory(): void
+    {
+        $finder = new Finder();
+
+        $repository = new LocalFilesRepository($finder);
+        $repository->within(__DIR__ . '/Fixtures/FileToInspect.php');
+        $files = iterator_to_array($repository->getFiles());
+
+        self::assertCount(1, $files);
+        self::assertInstanceOf(\SplFileInfo::class, $files[0]);
+        self::assertStringContainsString('/Fixtures/FileToInspect.php', $files[0]->getRealPath());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #148

This authorize the analyse of one file or a subdirectory.

To do this, I assume some Insight are "Globals" (ie all related to composer)

So when we launch an analyse on a subdirectory, I remove theses Insights in config.

For launch on a specific file, I modified the LocalFileRepository to append file directly in Finder.