### PR TITLE
Fix default preset "use in annotation" and fix merge config 

### DIFF
--- a/src/Application/Adapters/Drupal/Preset.php
+++ b/src/Application/Adapters/Drupal/Preset.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Adapters\Drupal;
 
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
@@ -22,7 +24,7 @@ final class Preset implements PresetContract
      */
     public static function get(): array
     {
-        return [
+        $config = [
             'exclude' => [
                 'core',
                 'modules/contrib',
@@ -39,6 +41,8 @@ final class Preset implements PresetContract
                 ],
             ],
         ];
+
+        return ConfigResolver::mergeConfig(DefaultPreset::get(), $config);
     }
 
     /**

--- a/src/Application/Adapters/Laravel/Preset.php
+++ b/src/Application/Adapters/Laravel/Preset.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Adapters\Laravel;
 
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineGlobalConstants;
 use NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff;
@@ -24,7 +26,7 @@ final class Preset implements PresetContract
      */
     public static function get(): array
     {
-        return [
+        $config = [
             'exclude' => [
                 'config',
                 'storage',
@@ -61,6 +63,8 @@ final class Preset implements PresetContract
                 ],
             ],
         ];
+
+        return ConfigResolver::mergeConfig(DefaultPreset::get(), $config);
     }
 
     /**

--- a/src/Application/Adapters/Magento2/Preset.php
+++ b/src/Application/Adapters/Magento2/Preset.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Adapters\Magento2;
 
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 
 /**
@@ -21,7 +23,7 @@ final class Preset implements PresetContract
      */
     public static function get(): array
     {
-        return [
+        $config = [
             'exclude' => [
                 'bin',
                 'dev',
@@ -47,6 +49,8 @@ final class Preset implements PresetContract
                 // ...
             ],
         ];
+
+        return ConfigResolver::mergeConfig(DefaultPreset::get(), $config);
     }
 
     /**

--- a/src/Application/Adapters/Symfony/Preset.php
+++ b/src/Application/Adapters/Symfony/Preset.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Adapters\Symfony;
 
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
@@ -22,7 +24,7 @@ final class Preset implements PresetContract
      */
     public static function get(): array
     {
-        return [
+        $config = [
             'exclude' => [
                 'var',
                 'translations',
@@ -38,6 +40,8 @@ final class Preset implements PresetContract
                 ],
             ],
         ];
+
+        return ConfigResolver::mergeConfig(DefaultPreset::get(), $config);
     }
 
     /**

--- a/src/Application/Adapters/Yii/Preset.php
+++ b/src/Application/Adapters/Yii/Preset.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Adapters\Yii;
 
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 
 /**
@@ -21,7 +23,7 @@ final class Preset implements PresetContract
      */
     public static function get(): array
     {
-        return [
+        $config = [
             'exclude' => [
                 'web',
                 'views',
@@ -38,6 +40,8 @@ final class Preset implements PresetContract
                 // ...
             ],
         ];
+
+        return ConfigResolver::mergeConfig(DefaultPreset::get(), $config);
     }
 
     /**

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -9,6 +9,7 @@ use NunoMaduro\PhpInsights\Application\Adapters\Laravel\Preset as LaravelPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Magento2\Preset as Magento2Preset;
 use NunoMaduro\PhpInsights\Application\Adapters\Symfony\Preset as SymfonyPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Yii\Preset as YiiPreset;
+use NunoMaduro\PhpInsights\Domain\Contracts\Preset;
 
 /**
  * @internal
@@ -39,13 +40,15 @@ final class ConfigResolver
     {
         $preset = $config['preset'] ?? self::guess($directory);
 
+        /** @var Preset $presetClass */
         foreach (self::$presets as $presetClass) {
-            if ($presetClass::getName() === $preset && is_array($config)) {
-                $config = array_replace_recursive($presetClass::get(), $config);
+            if ($presetClass::getName() === $preset) {
+                $config = self::mergeConfig($presetClass::get(), $config);
+                break;
             }
         }
 
-        return is_array($config) ? $config : [];
+        return $config ?? [];
     }
 
     /**
@@ -75,5 +78,34 @@ final class ConfigResolver
         }
 
         return $preset;
+    }
+
+    /**
+     * See https://www.php.net/manual/en/function.array-merge-recursive.php#96201
+     *
+     * @param mixed[] $base
+     * @param mixed[] $replacement
+     *
+     * @return mixed[]
+     */
+    public static function mergeConfig(array $base, array $replacement): array
+    {
+        foreach ($replacement as $key => $value) {
+            if (! array_key_exists($key, $base) && ! is_numeric($key)) {
+                $base[$key] = $replacement[$key];
+                continue;
+            }
+            if (is_array($value) || is_array($base[$key])) {
+                $base[$key] = self::mergeConfig($base[$key], $replacement[$key]);
+            } elseif (is_numeric($key)) {
+                if (! in_array($value, $base, true)) {
+                    $base[] = $value;
+                }
+            } else {
+                $base[$key] = $value;
+            }
+        }
+
+        return $base;
     }
 }

--- a/src/Application/DefaultPreset.php
+++ b/src/Application/DefaultPreset.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\PhpInsights\Application;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff;
+use SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff;
 
 /**
@@ -43,6 +44,9 @@ final class DefaultPreset implements PresetContract
                 DeclareStrictTypesSniff::class => [
                     'newlinesCountBetweenOpenTagAndDeclare' => 2,
                     'spacesCountAroundEqualsSign' => 0,
+                ],
+                UnusedUsesSniff::class => [
+                    'searchAnnotations' => true,
                 ],
             ],
         ];

--- a/src/Domain/Exceptions/PresetNotFound.php
+++ b/src/Domain/Exceptions/PresetNotFound.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Domain\Exceptions;
+
+/**
+ * @internal
+ */
+final class PresetNotFound extends \RuntimeException
+{
+}

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -6,6 +6,7 @@ namespace Tests\Application;
 
 use NunoMaduro\PhpInsights\Application\ConfigResolver;
 use PHPUnit\Framework\TestCase;
+use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff;
 
 final class ConfigResolverTest extends TestCase
 {
@@ -61,5 +62,33 @@ final class ConfigResolverTest extends TestCase
     {
         $preset = ConfigResolver::guess($this->baseFixturePath . 'ComposerDrupal');
         self::assertSame('drupal', $preset);
+    }
+
+    public function testResolveWithRightMerge(): void
+    {
+        $config = [
+            'exclude' => [
+                'my/path',
+            ],
+            'config' => [
+                DocCommentSpacingSniff::class => [
+                    'linesCountBetweenDifferentAnnotationsTypes' => 2
+                ]
+            ]
+        ];
+
+        $finalConfig = ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
+
+        self::assertArrayHasKey('exclude', $finalConfig);
+        self::assertArrayHasKey('config', $finalConfig);
+        self::assertContains('my/path', $finalConfig['exclude']);
+        // assert we don't replace the first value
+        self::assertContains('bower_components', $finalConfig['exclude']);
+        self::assertArrayHasKey(DocCommentSpacingSniff::class, $finalConfig['config']);
+        // assert we replace the config value
+        self::assertEquals(
+            2,
+            $finalConfig['config'][DocCommentSpacingSniff::class]['linesCountBetweenDifferentAnnotationsTypes']
+        );
     }
 }

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Application;
 
 use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Domain\Exceptions\PresetNotFound;
 use PHPUnit\Framework\TestCase;
 use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff;
 
@@ -64,7 +65,7 @@ final class ConfigResolverTest extends TestCase
         self::assertSame('drupal', $preset);
     }
 
-    public function testResolveWithRightMerge(): void
+    public function testResolvedConfigIsCorrectlyMerged(): void
     {
         $config = [
             'exclude' => [
@@ -90,5 +91,15 @@ final class ConfigResolverTest extends TestCase
             2,
             $finalConfig['config'][DocCommentSpacingSniff::class]['linesCountBetweenDifferentAnnotationsTypes']
         );
+    }
+
+    public function testUnknownPresetThrowException(): void
+    {
+        self::expectException(PresetNotFound::class);
+        self::expectExceptionMessage('UnknownPreset not found');
+
+        $config = ['preset' => 'UnknownPreset'];
+
+        ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #193 (and maybe #143 #145)

:thinking: This one may be controversial

I wanted to fix #193 by adding the config for `SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff` (with searchAnnotation to true) in DefaultPreset 

But I noticed that when we use an other framework preset, the config doesn't extend the default config.

After viewing issues #145, #143 and PR #111 and #147 I tried to fix them.

I before create a test that should cover all case (ie add an `exclude` path, and override a `config` value)

With the `array_replace_recursive`, we can override a config value, but we override also excluded path, so User had to rewrite the all list of exclude to bypass this problem. 

But with `array_merge_recursive`, the values passed in `config` for a sniff was joined into an array, that was not wanted also. 

As @dol mentionned [here](https://github.com/nunomaduro/phpinsights/pull/146#discussion_r288638081) and [here](https://github.com/nunomaduro/phpinsights/pull/147#issuecomment-498509938) the best option was to write a custom merge function that take care of numeric key. 

Once it was done, I also used this function to merge frameworks preset with the Default one.

@nunomaduro If you prefer I just focus on #193, I can remove the last three commits and only add UnusedUseSniff config in DefaultPreset.