### PR TITLE
[OnHold|Feat] Add PhpStan

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,11 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[*.php]
+ij_php_align_phpdoc_comments = false
+ij_php_align_phpdoc_param_names = false
+ij_php_phpdoc_use_fqcn = true
+ij_php_space_after_unary_not = true
+ij_php_force_short_declaration_array_style = true
+ij_php_comma_after_last_array_element = true

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -2,10 +2,7 @@
 
 The project is under development. As such, any help is welcome!
 
-1. [Create a new insight from scratch](#create-a-new-insight)
-2. [Add a new insight from PHP CS Sniff](#add-a-new-insight-from-php-cs-sniff)
-3. [Create or improve create a preset for your favorite framework](#create-or-improve-create-a-preset-for-your-favorite-framework)
-4. [Create the test suite](#create-the-test-suite)
+[[TOC]]
 
 ## Create a new `Insight`
 
@@ -129,3 +126,10 @@ final class Preset implements PresetContract
     }
 }
 ```
+
+## Create a new `Formatter`
+
+The package has support for formatting the result. 
+All formats implements the contract `src/Application/Console/Contracts/Formatter`.
+
+You are welcome to contribute with new formats or improve on the ones we already have.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -53,6 +53,31 @@ In laravel, launch command as usual with your path:
 php artisan insights path/to/analyse
 ```
 
+## Formatting the output
+
+For changing the output format you can add the `format` flag. The following formats are supported:
+
+- console
+- json
+
+```bash
+./vendor/bin/phpinsights analyse --format=json
+```
+
+## Saving output to file
+
+You can pipe the result to a file or to anywhere you like. 
+A common use case is parsing the output formatted as json to a json file.
+
+```bash
+./vendor/bin/phpinsights analyse --format=json > test.json
+```
+
+When piping the result remember to add the no interaction flag `-n`, as the part where you need to interact is also getting piped. (the json format does not have any interaction)
+While piping data, if you want the progress bar to refresh itself instead of printing a new one, add the `--ansi` flag.
+
+
+
 ## Allowed memory size of X bytes exhausted
 
 If you encounter the error `Allowed memory size of XXXXX bytes exhausted`, the current workaround is to increase the memory limit:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,6 +23,7 @@ parameters:
         - '#Language construct isset\(\) should not be used#'
         - '#Access to an undefined property PHP_CodeSniffer\\Config::\$standards.#'
         - '#Access to an undefined property PHP_CodeSniffer\\Sniffs\\Sniff::\$#'
+        - '#NunoMaduro\\PhpInsights\\Application\\Console\\Formatters\\Json has an unused parameter \$input#'
     autoload_files:
         - %rootDir%/../../squizlabs/php_codesniffer/autoload.php
     reportUnmatchedIgnoredErrors: false

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,101 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "readOnly": true,
+    "title": "The JSON format for phpinsights",
+    "required": [
+        "summary",
+        "Code",
+        "Complexity",
+        "Architecture",
+        "Style",
+        "Security"
+    ],
+    "definitions": {
+        "percentage": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+        },
+        "insight": {
+            "type": "object",
+            "required": [
+                "title",
+                "insightClass"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "insightClass": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "string"
+                },
+                "line": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "properties": {
+        "summary": {
+            "$id": "#/properties/summary",
+            "type": "object",
+            "title": "The Summary Schema",
+            "properties": {
+                "code": {
+                    "$ref": "#/definitions/percentage"
+                },
+                "complexity": {
+                    "$ref": "#/definitions/percentage"
+                },
+                "architecture": {
+                    "$ref": "#/definitions/percentage"
+                },
+                "style": {
+                    "$ref": "#/definitions/percentage"
+                },
+                "security issues": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            }
+        },
+        "Code": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/insight"
+            }
+        },
+        "Complexity": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/insight"
+            }
+        },
+        "Architecture": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/insight"
+            }
+        },
+        "Style": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/insight"
+            }
+        },
+        "Security": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/insight"
+            }
+        }
+    }
+}

--- a/src/Application/Console/Analyser.php
+++ b/src/Application/Console/Analyser.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Console;
 
+use NunoMaduro\PhpInsights\Application\Console\Contracts\Formatter;
 use NunoMaduro\PhpInsights\Domain\Insights\InsightCollectionFactory;
 use NunoMaduro\PhpInsights\Domain\MetricsFinder;
 use NunoMaduro\PhpInsights\Domain\Results;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
@@ -21,7 +23,7 @@ final class Analyser
     /**
      * Analyser constructor.
      *
-     * @param  \NunoMaduro\PhpInsights\Domain\Insights\InsightCollectionFactory  $insightCollectionFactory
+     * @param \NunoMaduro\PhpInsights\Domain\Insights\InsightCollectionFactory $insightCollectionFactory
      */
     public function __construct(InsightCollectionFactory $insightCollectionFactory)
     {
@@ -31,28 +33,27 @@ final class Analyser
     /**
      * Analyse the given dirs.
      *
-     * @param  \NunoMaduro\PhpInsights\Application\Console\Style  $style
-     * @param  array<string, array>  $config
-     * @param  string  $dir
+     * @param Formatter $format
+     * @param array<string, array> $config
+     * @param string $dir
+     * @param OutputInterface $consoleOutput
      *
      * @return  \NunoMaduro\PhpInsights\Domain\Results
      */
-    public function analyse(Style $style, array $config, string $dir): Results
+    public function analyse(
+        Formatter $format,
+        array $config,
+        string $dir,
+        OutputInterface $consoleOutput
+    ): Results
     {
         $metrics = MetricsFinder::find();
 
-        $insightCollection = $this->insightCollectionFactory->get($metrics, $config, $dir);
+        $insightCollection = $this->insightCollectionFactory
+            ->get($metrics, $config, $dir, $consoleOutput);
 
-        $results = $insightCollection->results();
+        $format->format($insightCollection, $dir, $metrics);
 
-        $style->header($results, $dir)
-            ->code($insightCollection, $results)
-            ->complexity($insightCollection, $results)
-            ->architecture($insightCollection, $results)
-            ->misc($results);
-
-        $style->issues($insightCollection, $metrics, $dir);
-
-        return $results;
+        return $insightCollection->results();
     }
 }

--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -6,11 +6,13 @@ namespace NunoMaduro\PhpInsights\Application\Console\Commands;
 
 use NunoMaduro\PhpInsights\Application\ConfigResolver;
 use NunoMaduro\PhpInsights\Application\Console\Analyser;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\FormatResolver;
 use NunoMaduro\PhpInsights\Application\Console\OutputDecorator;
 use NunoMaduro\PhpInsights\Application\Console\Style;
 use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
 use NunoMaduro\PhpInsights\Domain\Kernel;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -35,8 +37,8 @@ final class AnalyseCommand
     /**
      * Creates a new instance of the Analyse Command.
      *
-     * @param  \NunoMaduro\PhpInsights\Application\Console\Analyser  $analyser
-     * @param  \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository  $filesRepository
+     * @param \NunoMaduro\PhpInsights\Application\Console\Analyser $analyser
+     * @param \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository $filesRepository
      */
     public function __construct(Analyser $analyser, FilesRepository $filesRepository)
     {
@@ -47,14 +49,23 @@ final class AnalyseCommand
     /**
      * Handle the given input.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
      * @return int
      */
     public function __invoke(InputInterface $input, OutputInterface $output): int
     {
-        $style = new Style($input, OutputDecorator::decorate($output));
+        $consoleOutput = $output;
+        if ($consoleOutput instanceof ConsoleOutputInterface) {
+            $consoleOutput = $consoleOutput->getErrorOutput();
+            $consoleOutput->setDecorated($output->isDecorated());
+        }
+        $consoleStyle = new Style($input, $consoleOutput);
+
+        $output = OutputDecorator::decorate($output);
+
+        $format = FormatResolver::resolve($input, $output, $consoleOutput);
 
         $directory = $this->getDirectory($input);
 
@@ -70,26 +81,31 @@ final class AnalyseCommand
         if (! $isRootAnalyse) {
             $config = $this->excludeGlobalInsights($config);
         }
-        $results = $this->analyser->analyse($style, $config, $directory);
+        $results = $this->analyser->analyse(
+            $format,
+            $config,
+            $directory,
+            $consoleOutput
+        );
 
         $hasError = false;
         if ($input->getOption('min-quality') > $results->getCodeQuality()) {
-            $style->error('The code quality score is too low');
+            $consoleStyle->error('The code quality score is too low');
             $hasError = true;
         }
 
         if ($input->getOption('min-complexity') > $results->getComplexity()) {
-            $style->error('The complexity score is too low');
+            $consoleStyle->error('The complexity score is too low');
             $hasError = true;
         }
 
         if ($input->getOption('min-architecture') > $results->getStructure()) {
-            $style->error('The architecture score is too low');
+            $consoleStyle->error('The architecture score is too low');
             $hasError = true;
         }
 
         if ($input->getOption('min-style') > $results->getStyle()) {
-            $style->error('The style score is too low');
+            $consoleStyle->error('The style score is too low');
             $hasError = true;
         }
 
@@ -97,8 +113,8 @@ final class AnalyseCommand
             $hasError = true;
         }
 
-        $style->newLine();
-        $style->writeln('✨ See something that needs to be improved? <bold>Create an issue</> or send us a <bold>pull request</>: <title>https://github.com/nunomaduro/phpinsights</title>');
+        $consoleStyle->newLine();
+        $consoleStyle->writeln('✨ See something that needs to be improved? <bold>Create an issue</bold> or send us a <bold>pull request</bold>: <title>https://github.com/nunomaduro/phpinsights</title>');
 
         return (int) $hasError;
     }
@@ -106,8 +122,8 @@ final class AnalyseCommand
     /**
      * Gets the config from the given input.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  string  $directory
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param string $directory
      *
      * @return array<string, array>
      */
@@ -126,7 +142,7 @@ final class AnalyseCommand
     /**
      * Gets the directory from the given input.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param \Symfony\Component\Console\Input\InputInterface $input
      *
      * @return string
      */

--- a/src/Application/Console/Contracts/Formatter.php
+++ b/src/Application/Console/Contracts/Formatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application\Console\Contracts;
+
+use NunoMaduro\PhpInsights\Domain\Insights\InsightCollection;
+
+/**
+ * This interface is used to define the format of the result.
+ *
+ * @internal
+ */
+interface Formatter
+{
+    /**
+     * Format the result to the desired format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param string $dir
+     * @param array<string> $metrics
+     */
+    public function format(
+        InsightCollection $insightCollection,
+        string $dir,
+        array $metrics
+    ): void;
+}

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -63,6 +63,13 @@ final class AnalyseDefinition
                 InputOption::VALUE_NONE,
                 'Disable Security issues check to not throw error if vulnerability is found'
             ),
+            new InputOption(
+              'format',
+              null,
+              InputOption::VALUE_REQUIRED,
+                'Format to output the result in [console, json]',
+                "console"
+            ),
         ];
     }
 }

--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application\Console\Formatters;
+
+use NunoMaduro\PhpInsights\Application\Console\Contracts\Formatter;
+use NunoMaduro\PhpInsights\Application\Console\Style;
+use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
+use NunoMaduro\PhpInsights\Domain\Insights\InsightCollection;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Classes as ArchitectureClasses;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Files;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Globally as ArchitectureGlobally;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Interfaces as ArchitectureInterfaces;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Traits as ArchitectureTraits;
+use NunoMaduro\PhpInsights\Domain\Metrics\Code\Classes;
+use NunoMaduro\PhpInsights\Domain\Metrics\Code\Code;
+use NunoMaduro\PhpInsights\Domain\Metrics\Code\Comments;
+use NunoMaduro\PhpInsights\Domain\Metrics\Code\Functions;
+use NunoMaduro\PhpInsights\Domain\Metrics\Code\Globally;
+use NunoMaduro\PhpInsights\Domain\Metrics\Complexity\Complexity;
+use NunoMaduro\PhpInsights\Domain\Results;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class Console implements Formatter
+{
+    /** @var Style */
+    private $style;
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->style = new Style($input, $output);
+    }
+
+    /**
+     * Format the result to the desired format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param string $dir
+     * @param array<string> $metrics
+     */
+    public function format(
+        InsightCollection $insightCollection,
+        string $dir,
+        array $metrics
+    ): void
+    {
+        $results = $insightCollection->results();
+
+        $this->summary($results, $dir)
+            ->code($insightCollection, $results)
+            ->complexity($insightCollection, $results)
+            ->architecture($insightCollection, $results)
+            ->miscellaneous($results);
+
+        $this->issues($insightCollection, $metrics, $dir);
+    }
+
+    /**
+     * Outputs the summary according to the format.
+     *
+     * @param Results $results
+     * @param string $dir
+     *
+     * @return self
+     */
+    private function summary(Results $results, string $dir): self
+    {
+        $this->style->newLine(2);
+
+        $this->style->writeln(
+            sprintf(
+                '<fg=yellow>[%s]</> `%s`',
+                date('Y-m-d H:i:s'),
+                $dir
+            )
+        );
+
+        $subtitle = 'fg=white;options=bold;fg=white';
+        $this->style->newLine();
+
+        $codeQualityColor = "bg={$this->getColor($results->getCodeQuality())}";
+        $complexityColor = "bg={$this->getColor($results->getComplexity())}";
+        $structureColor = "bg={$this->getColor($results->getStructure())}";
+        $styleColor = "bg={$this->getColor($results->getStyle())}";
+
+        $codeQuality = self::getPercentageAsString($results->getCodeQuality());
+        $complexity = self::getPercentageAsString($results->getComplexity());
+        $structure = self::getPercentageAsString($results->getStructure());
+        $style = self::getPercentageAsString($results->getStyle());
+
+        $output = <<<EOD
+      <$codeQualityColor>         </>            <$complexityColor>         </>            <$structureColor>         </>            <$styleColor>         </>
+      <fg=black;options=bold;$codeQualityColor>  {$codeQuality}  </>            <fg=black;options=bold;$complexityColor>  {$complexity}  </>            <fg=black;options=bold;$structureColor>  {$structure}  </>            <fg=black;options=bold;$styleColor>  {$style}  </>
+      <$codeQualityColor>         </>            <$complexityColor>         </>            <$structureColor>         </>            <$styleColor>         </>
+
+        <$subtitle>Code</>               <$subtitle>Complexity</>          <$subtitle>Architecture</>            <$subtitle>Style</>
+EOD;
+        $this->style->write($output);
+        $this->style->newLine(2);
+
+        $this->style->writeln("Score scale: <fg=red>◼</> 1-49 <fg=yellow>◼</> 50-79 <fg=green>◼</> 80-100");
+
+        return $this;
+    }
+
+    /**
+     * Outputs the code errors according to the format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param Results $results
+     *
+     * @return self
+     */
+    private function code(
+        InsightCollection $insightCollection,
+        Results $results
+    ): self
+    {
+        $this->style->newLine();
+        $this->style->writeln(sprintf("[CODE] %s within <title>%s</title> lines",
+            "<fg={$this->getColor($results->getCodeQuality())};options=bold>{$results->getCodeQuality()} pts</>",
+            (new Code())->getValue($insightCollection->getCollector())
+        ));
+        $this->style->newLine();
+
+        $lines = [];
+        foreach ([
+                     Comments::class,
+                     Classes::class,
+                     Functions::class,
+                     Globally::class,
+                 ] as $metric) {
+            $name = explode('\\', $metric);
+            $lines[end($name)] = (new $metric())->getPercentage($insightCollection->getCollector());
+        }
+
+        foreach ($lines as $name => $percentage) {
+            $percentage = number_format((float) $percentage, 1, '.', '');
+
+            $takenSize = strlen($name . $percentage);
+
+            $this->style->writeln(sprintf('%s %s %s %%',
+                $name,
+                str_repeat('.', 70 - $takenSize),
+                $percentage
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Outputs the complexity errors according to the format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param Results $results
+     *
+     * @return self
+     */
+    private function complexity(
+        InsightCollection $insightCollection,
+        Results $results
+    ): self
+    {
+        $this->style->newLine();
+
+        $this->style->writeln(sprintf("[COMPLEXITY] %s with average of <title>%s</title> cyclomatic complexity",
+            "<fg={$this->getColor($results->getComplexity())};options=bold>{$results->getComplexity()} pts</>",
+            (new Complexity())->getAvg($insightCollection->getCollector())
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Outputs the architecture errors according to the format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param Results $results
+     *
+     * @return self
+     */
+    private function architecture(
+        InsightCollection $insightCollection,
+        Results $results
+    ): self
+    {
+        $this->style->newLine();
+
+        $this->style->writeln(sprintf("[ARCHITECTURE] %s within <title>%s</title> files",
+            "<fg={$this->getColor($results->getStructure())};options=bold>{$results->getStructure()} pts</>",
+            (new Files())->getValue($insightCollection->getCollector())
+        ));
+
+        $this->style->newLine();
+
+        $lines = [];
+        foreach ([
+            ArchitectureClasses::class,
+            ArchitectureInterfaces::class,
+            ArchitectureGlobally::class,
+            ArchitectureTraits::class,
+        ] as $metric) {
+            $name = explode('\\', $metric);
+            $lines[end($name)] = (new $metric())->getPercentage($insightCollection->getCollector());
+        }
+
+        foreach ($lines as $name => $percentage) {
+            $percentage = number_format((float) $percentage, 1, '.', '');
+
+            $takenSize = strlen($name . $percentage);
+
+            $this->style->writeln(sprintf('%s %s %s %%',
+                $name,
+                str_repeat('.', 70 - $takenSize),
+                $percentage
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Outputs the miscellaneous errors according to the format.
+     *
+     * @param Results $results
+     *
+     * @return self
+     */
+    private function miscellaneous(
+        Results $results
+    ): self
+    {
+        $this->style->newLine();
+
+        $message = sprintf(
+            '[MISC] %s on coding style',
+            "<fg={$this->getColor($results->getStyle())};options=bold>{$results->getStyle()} pts</>");
+
+        if ($results->hasInsightInCategory(ForbiddenSecurityIssues::class, 'Security')) {
+            $totalSecurityIssuesColor = $results->getTotalSecurityIssues() === 0 ? 'green' : 'red';
+            $message .= sprintf(
+                ' and %s encountered',
+                "<fg={$totalSecurityIssuesColor};options=bold>{$results->getTotalSecurityIssues()} security issues</>"
+            );
+        }
+
+        $this->style->writeln($message);
+
+        return $this;
+    }
+
+    /**
+     * Outputs the issues errors according to the format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param array<string> $metrics
+     * @param string $dir
+     *
+     * @return self
+     */
+    private function issues(
+        InsightCollection $insightCollection,
+        array $metrics,
+        string $dir
+    ): self
+    {
+        $previousCategory = null;
+
+        foreach ($metrics as $metricClass) {
+            foreach ($insightCollection->allFrom(new $metricClass()) as $insight) {
+                if (! $insight->hasIssue()) {
+                    continue;
+                }
+
+                $category = explode('\\', $metricClass);
+                $category = $category[count($category) - 2];
+
+                if ($previousCategory !== $category) {
+                    $this->style->waitForKey($category);
+                }
+
+                $previousCategory = $category;
+
+                $issue = "\n<fg=red>•</> [$category] <bold>{$insight->getTitle()}</bold>";
+
+                if (! $insight instanceof HasDetails && ! $this->style->output->isVerbose()) {
+                    $this->style->writeln($issue);
+                    continue;
+                }
+                $issue .= ':';
+                if ($this->style->output->isVerbose()) {
+                    $issue .= " ({$insight->getInsightClass()})";
+                }
+
+                if (! $insight instanceof HasDetails) {
+                    $this->style->writeln($issue);
+                    continue;
+                }
+
+                $details = $insight->getDetails();
+                $totalDetails = count($details);
+
+                if (! $this->style->output->isVerbose()) {
+                    $details = array_slice($details, -3, 3, true);
+                }
+
+                /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */
+                foreach ($details as $detail) {
+                    $detailString = null;
+                    if ($detail->hasFile()) {
+                        $detailString .= str_replace(realpath($dir) . '/', '', $detail->getFile());
+                    }
+
+                    if ($detail->hasLine()) {
+                        $detailString .= ($detailString !== null ? ':' : '') . $detail->getLine();
+                    }
+
+                    if ($detail->hasFunction()) {
+                        $detailString .= ($detailString !== null ? ':' : '') . $detail->getFunction();
+                    }
+
+                    if ($detail->hasMessage()) {
+                        $detailString .= ($detailString !== null ? ': ' : '') . $detail->getMessage();
+                    }
+
+                    $issue .= "\n  $detailString";
+                }
+
+                if (! $this->style->output->isVerbose() && $totalDetails > 3) {
+                    $totalRemainDetails = $totalDetails - 3;
+
+                    $issue .= "\n  <fg=red>+{$totalRemainDetails} issues omitted</>";
+                }
+
+                $this->style->writeln($issue);
+            }
+        }
+
+        return $this;
+    }
+
+
+    /**
+     * Returns the percentage as 5 chars string.
+     *
+     * @param float $percentage
+     *
+     * @return string
+     */
+    private static function getPercentageAsString(float $percentage): string
+    {
+        $percentageString = sprintf('%s%%', $percentage === 100.0
+            ? '100 '
+            : number_format($percentage, 1, '.', ''));
+
+        return str_pad($percentageString, 5);
+    }
+
+    /**
+     * Returns the color for the given percentage.
+     *
+     * @param float $percentage
+     *
+     * @return string
+     */
+    private function getColor(float $percentage): string
+    {
+        if ($percentage >= 80) {
+            return 'green';
+        }
+
+        if ($percentage >= 50) {
+            return 'yellow';
+        }
+
+        return 'red';
+    }
+}

--- a/src/Application/Console/Formatters/FormatResolver.php
+++ b/src/Application/Console/Formatters/FormatResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application\Console\Formatters;
+
+use InvalidArgumentException;
+use NunoMaduro\PhpInsights\Application\Console\Contracts\Formatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class FormatResolver
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $formatters = [
+        'console' => Console::class,
+        'json' => Json::class,
+    ];
+
+    public static function resolve(
+        InputInterface $input,
+        OutputInterface $output,
+        OutputInterface $consoleOutput
+    ): Formatter
+    {
+        $requestedFormat = $input->getOption('format');
+
+        if (! is_string($requestedFormat)) {
+            throw new InvalidArgumentException(
+                "Format has to be a string."
+            );
+        }
+
+        $requestedFormat = strtolower($requestedFormat);
+
+        if (! array_key_exists($requestedFormat, self::$formatters)) {
+            $consoleOutput->writeln("<fg=red>Could not find requested format [$requestedFormat], using fallback [console] instead.</>");
+        }
+
+        $formatter = self::$formatters[$requestedFormat] ?? Console::class;
+
+        return new $formatter($input, $output);
+    }
+
+}

--- a/src/Application/Console/Formatters/Json.php
+++ b/src/Application/Console/Formatters/Json.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application\Console\Formatters;
+
+use Exception;
+use InvalidArgumentException;
+use NunoMaduro\PhpInsights\Application\Console\Contracts\Formatter;
+use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Insights\Insight;
+use NunoMaduro\PhpInsights\Domain\Insights\InsightCollection;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class Json implements Formatter
+{
+    /** @var OutputInterface */
+    private $output;
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Format the result to the desired format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param string $dir
+     * @param array<string> $metrics
+     *
+     * @throws Exception
+     */
+    public function format(
+        InsightCollection $insightCollection,
+        string $dir,
+        array $metrics
+    ): void
+    {
+        $results = $insightCollection->results();
+
+        $data = [
+            "summary" => [
+                "code" => $results->getCodeQuality(),
+                "complexity" => $results->getComplexity(),
+                'architecture' => $results->getStructure(),
+                'style' => $results->getStyle(),
+                'security issues' => $results->getTotalSecurityIssues(),
+            ],
+        ];
+        $data += $this->issues($insightCollection, $metrics);
+
+        $json = json_encode($data);
+
+        if ($json === false) {
+            throw new InvalidArgumentException("Failed parsing result to JSON.");
+        }
+
+        $this->output->write($json);
+    }
+
+    /**
+     * Outputs the issues errors according to the format.
+     *
+     * @param InsightCollection $insightCollection
+     * @param array<string> $metrics
+     *
+     * @return array<string, array<int, array<string, int|string>>|null>
+     */
+    private function issues(
+        InsightCollection $insightCollection,
+        array $metrics
+    ): array
+    {
+        $data = [];
+
+        foreach ($metrics as $metricClass) {
+            $category = explode('\\', $metricClass);
+            $category = $category[count($category) - 2];
+
+            if (! isset($data[$category])) {
+                $data[$category] = [];
+            }
+
+            $current = $data[$category];
+
+            /** @var Insight $insight */
+            foreach ($insightCollection->allFrom(new $metricClass()) as $insight) {
+                if (! $insight->hasIssue()) {
+                    continue;
+                }
+
+                if (! $insight instanceof HasDetails) {
+                    $current[] = [
+                        'title' => $insight->getTitle(),
+                        'insightClass' => $insight->getInsightClass(),
+                    ];
+                    continue;
+                }
+
+                /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */
+                foreach ($insight->getDetails() as $detail) {
+                    $current[] = array_filter([
+                        'title' => $insight->getTitle(),
+                        'insightClass' => $insight->getInsightClass(),
+                        'file' => $detail->hasFile() ? $detail->getFile() : null,
+                        'line' => $detail->hasLine() ? $detail->getLine() : null,
+                        'function' => $detail->hasFunction() ? $detail->getFunction() : null,
+                        'message' => $detail->hasMessage() ? $detail->getMessage() : null,
+                    ]);
+                }
+            }
+
+            $data[$category] = $current;
+        }
+
+        return $data;
+    }
+}

--- a/src/Application/Console/Style.php
+++ b/src/Application/Console/Style.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Console;
 
-use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
-use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
-use NunoMaduro\PhpInsights\Domain\Insights\InsightCollection;
-use NunoMaduro\PhpInsights\Domain\Metrics\Architecture;
-use NunoMaduro\PhpInsights\Domain\Metrics\Code;
-use NunoMaduro\PhpInsights\Domain\Metrics\Complexity;
-use NunoMaduro\PhpInsights\Domain\Results;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,13 +22,13 @@ final class Style extends SymfonyStyle
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
      */
-    private $output;
+    public $output;
 
     /**
      * Style constructor.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     public function __construct(InputInterface $input, OutputInterface $output)
     {
@@ -43,239 +36,9 @@ final class Style extends SymfonyStyle
     }
 
     /**
-     * @param  \NunoMaduro\PhpInsights\Domain\Results  $results
-     * @param  string  $dir
-     *
-     * @return \NunoMaduro\PhpInsights\Application\Console\Style
-     */
-    public function header(Results $results, string $dir): Style
-    {
-        $this->newLine(2);
-
-        $this->writeln(sprintf('<fg=yellow>[%s]</> `%s`', date('Y-m-d H:i:s'), $dir));
-
-        $subtitle = 'fg=white;options=bold;fg=white';
-        $this->newLine();
-
-        $codeQualityColor = "bg={$this->getColor($results->getCodeQuality())}";
-        $complexityColor = "bg={$this->getColor($results->getComplexity())}";
-        $structureColor = "bg={$this->getColor($results->getStructure())}";
-        $styleColor = "bg={$this->getColor($results->getStyle())}";
-
-        $codeQuality = self::getPercentageAsString($results->getCodeQuality());
-        $complexity = self::getPercentageAsString($results->getComplexity());
-        $structure = self::getPercentageAsString($results->getStructure());
-        $style = self::getPercentageAsString($results->getStyle());
-
-        $output = <<<EOD
-      <$codeQualityColor>         </>            <$complexityColor>         </>            <$structureColor>         </>            <$styleColor>         </>
-      <fg=black;options=bold;$codeQualityColor>  {$codeQuality}  </>            <fg=black;options=bold;$complexityColor>  {$complexity}  </>            <fg=black;options=bold;$structureColor>  {$structure}  </>            <fg=black;options=bold;$styleColor>  {$style}  </>
-      <$codeQualityColor>         </>            <$complexityColor>         </>            <$structureColor>         </>            <$styleColor>         </>
-
-        <$subtitle>Code</>               <$subtitle>Complexity</>          <$subtitle>Architecture</>            <$subtitle>Style</>
-EOD;
-        $this->write($output);
-        $this->newLine(2);
-
-        $this->writeln("Score scale: <fg=red>◼</> 1-49 <fg=yellow>◼</> 50-79 <fg=green>◼</> 80-100");
-
-        return $this;
-    }
-
-    /**
-     * @param  \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection  $insightCollection
-     * @param  \NunoMaduro\PhpInsights\Domain\Results  $results
-     *
-     * @return \NunoMaduro\PhpInsights\Application\Console\Style
-     */
-    public function code(InsightCollection $insightCollection, Results $results): Style
-    {
-        $this->newLine();
-        $this->writeln(sprintf("[CODE] %s within <title>%s</> lines",
-            "<fg={$this->getColor($results->getCodeQuality())};options=bold>{$results->getCodeQuality()} pts</>",
-            (new Code\Code())->getValue($insightCollection->getCollector())
-        ));
-        $this->newLine();
-
-        $lines = [];
-        foreach ([Code\Comments::class, Code\Classes::class, Code\Functions::class, Code\Globally::class] as $metric) {
-            $name = explode('\\', $metric);
-            $lines[end($name)] = (new $metric())
-                ->getPercentage($insightCollection->getCollector());
-        }
-
-        foreach ($lines as $name => $percentage) {
-            $percentage = number_format((float) $percentage, 1, '.', '');
-
-            $takenSize = strlen($name . $percentage);
-
-            $this->writeln(sprintf('%s %s %s %%',
-                $name,
-                str_repeat('.', 70 - $takenSize),
-                $percentage
-            ));
-        }
-
-        return $this;
-    }
-
-
-    /**
-     * @param  \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection  $insightCollection
-     * @param  \NunoMaduro\PhpInsights\Domain\Results  $results
-     *
-     * @return \NunoMaduro\PhpInsights\Application\Console\Style
-     */
-    public function complexity(InsightCollection $insightCollection, Results $results): Style
-    {
-        $this->newLine();
-
-        $this->writeln(sprintf("[COMPLEXITY] %s with average of <title>%s</> cyclomatic complexity",
-            "<fg={$this->getColor($results->getComplexity())};options=bold>{$results->getComplexity()} pts</>",
-            (new Complexity\Complexity())->getAvg($insightCollection->getCollector())
-        ));
-
-        return $this;
-    }
-
-    /**
-     * @param  \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection  $insightCollection
-     * @param  \NunoMaduro\PhpInsights\Domain\Results  $results
-     *
-     * @return \NunoMaduro\PhpInsights\Application\Console\Style
-     */
-    public function architecture(InsightCollection $insightCollection, Results $results): Style
-    {
-        $this->newLine();
-
-        $this->writeln(sprintf("[ARCHITECTURE] %s within <title>%s</> files",
-            "<fg={$this->getColor($results->getStructure())};options=bold>{$results->getStructure()} pts</>",
-            (new Architecture\Files())->getValue($insightCollection->getCollector())
-        ));
-
-        $this->newLine();
-
-        $lines = [];
-        foreach ([Architecture\Classes::class, Architecture\Interfaces::class, Architecture\Globally::class, Architecture\Traits::class] as $metric) {
-            $name = explode('\\', $metric);
-            $lines[end($name)] = (new $metric())
-                ->getPercentage($insightCollection->getCollector());
-        }
-
-        foreach ($lines as $name => $percentage) {
-            $percentage = number_format((float) $percentage, 1, '.', '');
-
-            $takenSize = strlen($name . $percentage);
-
-            $this->writeln(sprintf('%s %s %s %%',
-                $name,
-                str_repeat('.', 70 - $takenSize),
-                $percentage
-            ));
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param  \NunoMaduro\PhpInsights\Domain\Results  $results
-     *
-     * @return \NunoMaduro\PhpInsights\Application\Console\Style
-     */
-    public function misc(Results $results): Style
-    {
-        $this->newLine();
-
-        $message = sprintf(
-            '[MISC] %s on coding style',
-            "<fg={$this->getColor($results->getStyle())};options=bold>{$results->getStyle()} pts</>");
-
-        if ($results->hasInsightInCategory(ForbiddenSecurityIssues::class, 'Security')) {
-            $totalSecurityIssuesColor = $results->getTotalSecurityIssues() === 0 ? 'green' : 'red';
-            $message .= sprintf(
-                ' and %s encountered',
-                "<fg={$totalSecurityIssuesColor};options=bold>{$results->getTotalSecurityIssues()} security issues</>"
-            );
-        }
-
-        $this->writeln($message);
-
-        return $this;
-    }
-
-    /**
-     * Describes the issues from the given metrics.
-     *
-     * @param  \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection  $insightCollection
-     * @param array<string> $metrics
-     * @param  string  $dir
-     *
-     * @return \NunoMaduro\PhpInsights\Application\Console\Style
-     */
-    public function issues(InsightCollection $insightCollection, array $metrics, string $dir): Style
-    {
-        $previousCategory = null;
-
-        foreach ($metrics as $metricClass) {
-            foreach ($insightCollection->allFrom(new $metricClass()) as $insight) {
-                if (! $insight->hasIssue()) {
-                    continue;
-                }
-
-                $category = explode('\\', $metricClass);
-                $category = $category[count($category) - 2];
-
-                if ($previousCategory !== $category) {
-                    $this->waitForKey($category);
-                }
-
-                $previousCategory = $category;
-
-                $issue = "\n<fg=red>•</> [$category] <bold>{$insight->getTitle()}</bold>";
-
-                if (! $insight instanceof HasDetails && ! $this->output->isVerbose()) {
-                    $this->writeln($issue);
-                    continue;
-                }
-                $issue .= ':';
-                if ($this->output->isVerbose()) {
-                    $issue .= " ({$insight->getInsightClass()})";
-                }
-
-                if (! $insight instanceof HasDetails) {
-                    $this->writeln($issue);
-                    continue;
-                }
-
-                $details = $insight->getDetails();
-                $totalDetails = count($details);
-
-                if (! $this->output->isVerbose()) {
-                    $details = array_slice($details, -3, 3, true);
-                }
-
-                foreach ($details as $detail) {
-                    $detail = str_replace(realpath($dir) . '/', '', $detail);
-                    $issue .= "\n  $detail";
-                }
-
-                if (! $this->output->isVerbose() && $totalDetails > 3) {
-                    $totalRemainDetails = $totalDetails - 3;
-
-                    $issue .= "\n  <fg=red>+{$totalRemainDetails} issues omitted</>";
-                }
-
-                $this->writeln($issue);
-            }
-        }
-
-        return $this;
-    }
-
-    /**
      * Waits for Enter key.
      *
-     * @param  string  $category
+     * @param string $category
      *
      * @return \NunoMaduro\PhpInsights\Application\Console\Style
      */
@@ -292,41 +55,5 @@ EOD;
         }
 
         return $this;
-    }
-
-    /**
-     * Returns the percentage as 5 chars string.
-     *
-     * @param  float  $percentage
-     *
-     * @return string
-     */
-    private static function getPercentageAsString(float $percentage): string
-    {
-        $percentageString = sprintf('%s%%', $percentage === 100.0
-            ? '100 '
-            : number_format($percentage, 1, '.', ''));
-
-        return str_pad($percentageString, 5);
-    }
-
-    /**
-     * Returns the color for the given percentage.
-     *
-     * @param  float  $percentage
-     *
-     * @return string
-     */
-    private function getColor(float $percentage): string
-    {
-        if ($percentage >= 80) {
-            return 'green';
-        }
-
-        if ($percentage >= 50) {
-            return 'yellow';
-        }
-
-        return 'red';
     }
 }

--- a/src/Domain/Contracts/HasDetails.php
+++ b/src/Domain/Contracts/HasDetails.php
@@ -12,7 +12,7 @@ interface HasDetails extends Insight
     /**
      * Returns the details of the insight.
      *
-     * @return array<string>
+     * @return array<\NunoMaduro\PhpInsights\Domain\Details>
      */
     public function getDetails(): array;
 }

--- a/src/Domain/Details.php
+++ b/src/Domain/Details.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Domain;
+
+final class Details
+{
+    /** @var mixed */
+    private $original;
+
+    /** @var string */
+    private $file;
+
+    /** @var int */
+    private $line;
+
+    /** @var string  */
+    private $function;
+
+    /** @var string */
+    private $message;
+
+    public static function make(): Details
+    {
+        return new Details();
+    }
+
+    public function withFile(string $file): Details
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * @param mixed $original
+     *
+     * @return Details
+     */
+    public function withOriginal($original): Details
+    {
+        $this->original = $original;
+        return $this;
+    }
+
+    public function withLine(int $line): Details
+    {
+        $this->line = $line;
+        return $this;
+    }
+
+    public function withMessage(string $message): Details
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    public function withFunction(string $function): Details
+    {
+        $this->function = $function;
+        return $this;
+    }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function hasFile(): bool
+    {
+        return $this->file !== null;
+    }
+
+    public function getLine(): int
+    {
+        return $this->line;
+    }
+
+    public function hasLine(): bool
+    {
+        return $this->line !== null;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function hasMessage(): bool
+    {
+        return $this->message !== null;
+    }
+
+    public function getFunction(): string
+    {
+        return $this->function;
+    }
+
+    public function hasFunction(): bool
+    {
+        return $this->function !== null;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOriginal()
+    {
+        return $this->original;
+    }
+
+    public function hasOriginal(): bool
+    {
+        return $this->original !== null;
+    }
+}

--- a/src/Domain/FileProcessor.php
+++ b/src/Domain/FileProcessor.php
@@ -75,9 +75,11 @@ final class FileProcessor implements FileProcessorInterface
     }
 
     /**
-     * @param  \Symplify\PackageBuilder\FileSystem\SmartFileInfo  $smartFileInfo
+     * @param \Symplify\PackageBuilder\FileSystem\SmartFileInfo $smartFileInfo
      *
      * @return string
+     *
+     * @throws \Throwable
      */
     public function processFile(SmartFileInfo $smartFileInfo): string
     {

--- a/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
+++ b/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\PhpInsights\Domain\Insights\Composer;
 
 use NunoMaduro\PhpInsights\Domain\ComposerLoader;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Exceptions\ComposerNotFound;
 use NunoMaduro\PhpInsights\Domain\Insights\Insight;
 
@@ -29,6 +30,9 @@ final class ComposerLockMustBeFresh extends Insight implements HasDetails
 
     public function getDetails(): array
     {
-        return ['You may be getting outdated dependencies. Run update to update them.'];
+        return [
+            Details::make()
+                ->withMessage('You may be getting outdated dependencies. Run update to update them.'),
+        ];
     }
 }

--- a/src/Domain/Insights/Composer/ComposerMustBeValid.php
+++ b/src/Domain/Insights/Composer/ComposerMustBeValid.php
@@ -8,6 +8,7 @@ use Composer\IO\NullIO;
 use Composer\Util\ConfigValidator;
 use NunoMaduro\PhpInsights\Domain\ComposerFinder;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Insights\Insight;
 
 final class ComposerMustBeValid extends Insight implements HasDetails
@@ -46,7 +47,9 @@ final class ComposerMustBeValid extends Insight implements HasDetails
             if (strpos($issue, ' : ') !== false) {
                 $issue = explode(' : ', $issue)[1];
             }
-            $details[] = 'composer.json: ' . $issue;
+            $details[] = Details::make()
+                ->withFile('composer.json')
+                ->withMessage($issue);
         }
 
         return $details;

--- a/src/Domain/Insights/CyclomaticComplexityIsHigh.php
+++ b/src/Domain/Insights/CyclomaticComplexityIsHigh.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 
 final class CyclomaticComplexityIsHigh extends Insight implements HasDetails
 {
@@ -47,8 +48,10 @@ final class CyclomaticComplexityIsHigh extends Insight implements HasDetails
 
         $classesComplexity = array_reverse($classesComplexity);
 
-        return array_map(static function ($class, $complexity) {
-            return "$class: $complexity cyclomatic complexity";
+        return array_map(static function ($class, $complexity): Details {
+            return Details::make()
+                ->withFile($class)
+                ->withMessage("$complexity cyclomatic complexity");
         }, array_keys($classesComplexity), $classesComplexity);
     }
 

--- a/src/Domain/Insights/ForbiddenDefineFunctions.php
+++ b/src/Domain/Insights/ForbiddenDefineFunctions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 
 final class ForbiddenDefineFunctions extends Insight implements HasDetails
 {
@@ -29,7 +30,10 @@ final class ForbiddenDefineFunctions extends Insight implements HasDetails
         foreach ($namedFunctionsPerFile as $file => $namedFunctions) {
             foreach ($namedFunctions as $key => $namedFunction) {
                 $number = $key + 1;
-                $details[] = "$file:{$number}:$namedFunction";
+                $details[] = Details::make()
+                    ->withFile($file)
+                    ->withLine($number)
+                    ->withFunction($namedFunction);
             }
         }
 

--- a/src/Domain/Insights/ForbiddenDefineGlobalConstants.php
+++ b/src/Domain/Insights/ForbiddenDefineGlobalConstants.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 
 final class ForbiddenDefineGlobalConstants extends Insight implements HasDetails
 {
@@ -32,8 +33,10 @@ final class ForbiddenDefineGlobalConstants extends Insight implements HasDetails
 
         $globalConstants = array_diff($this->collector->getGlobalConstants(), $ignore);
 
-        return array_map(static function ($file, $constant) {
-            return "$file: $constant";
+        return array_map(static function ($file, $constant): Details {
+            return Details::make()
+                ->withFile($file)
+                ->withMessage($constant);
         }, array_keys($globalConstants), $globalConstants);
     }
 }

--- a/src/Domain/Insights/ForbiddenFinalClasses.php
+++ b/src/Domain/Insights/ForbiddenFinalClasses.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 
 final class ForbiddenFinalClasses extends Insight implements HasDetails
 {
@@ -23,6 +24,8 @@ final class ForbiddenFinalClasses extends Insight implements HasDetails
      */
     public function getDetails(): array
     {
-        return $this->collector->getConcreteFinalClasses();
+        return array_map(static function (string $name): Details {
+            return Details::make()->withFile($name);
+        }, $this->collector->getConcreteFinalClasses());
     }
 }

--- a/src/Domain/Insights/ForbiddenNormalClasses.php
+++ b/src/Domain/Insights/ForbiddenNormalClasses.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 
 final class ForbiddenNormalClasses extends Insight implements HasDetails
 {
@@ -23,6 +24,8 @@ final class ForbiddenNormalClasses extends Insight implements HasDetails
      */
     public function getDetails(): array
     {
-        return $this->collector->getConcreteNonFinalClasses();
+        return array_map(static function (string $file): Details {
+            return Details::make()->withFile($file);
+        }, $this->collector->getConcreteNonFinalClasses());
     }
 }

--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Exceptions\InternetConnectionNotFound;
 use SensioLabs\Security\Result;
 use SensioLabs\Security\SecurityChecker;
@@ -41,7 +42,9 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails
 
         foreach ($issues as $packageName => $package) {
             foreach ($package['advisories'] as $advisory) {
-                $details[] = "$packageName@{$package['version']} {$advisory['title']} - {$advisory['link']}";
+                $details[] = Details::make()->withMessage(
+                    "$packageName@{$package['version']} {$advisory['title']} - {$advisory['link']}"
+                );
             }
         }
 

--- a/src/Domain/Insights/ForbiddenTraits.php
+++ b/src/Domain/Insights/ForbiddenTraits.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
+use NunoMaduro\PhpInsights\Domain\Details;
 
 final class ForbiddenTraits extends Insight implements HasDetails
 {
@@ -23,6 +24,8 @@ final class ForbiddenTraits extends Insight implements HasDetails
      */
     public function getDetails(): array
     {
-        return $this->collector->getTraits();
+        return array_map(static function (string $name): Details {
+            return Details::make()->withFile($name);
+        }, $this->collector->getTraits());
     }
 }

--- a/src/Domain/Insights/InsightCollectionFactory.php
+++ b/src/Domain/Insights/InsightCollectionFactory.php
@@ -9,6 +9,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\HasInsights;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
 use NunoMaduro\PhpInsights\Domain\Exceptions\DirectoryNotFound;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
@@ -28,8 +29,8 @@ final class InsightCollectionFactory
     /**
      * Creates a new instance of InsightCollection Factory.
      *
-     * @param  \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository  $filesRepository
-     * @param  \NunoMaduro\PhpInsights\Domain\Analyser  $analyser
+     * @param \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository $filesRepository
+     * @param \NunoMaduro\PhpInsights\Domain\Analyser $analyser
      */
     public function __construct(FilesRepository $filesRepository, Analyser $analyser)
     {
@@ -39,12 +40,18 @@ final class InsightCollectionFactory
 
     /**
      * @param array<string> $metrics
-     * @param  array<string, array<string, string>>  $config
-     * @param  string  $dir
+     * @param array<string, array<string, string>> $config
+     * @param string $dir
+     * @param OutputInterface $consoleOutput
      *
      * @return \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection
      */
-    public function get(array $metrics, array $config, string $dir): InsightCollection
+    public function get(
+        array $metrics,
+        array $config,
+        string $dir,
+        OutputInterface $consoleOutput
+    ): InsightCollection
     {
         try {
             $files = array_map(static function (\SplFileInfo $file) {
@@ -65,12 +72,13 @@ final class InsightCollectionFactory
         $insightFactory = new InsightFactory($this->filesRepository, $dir, $insightsClasses);
         $insightsForCollection = [];
         foreach ($metrics as $metricClass) {
-            $insightsForCollection[$metricClass] = array_map(static function (string $insightClass) use ($insightFactory, $collector, $config) {
+            $insightsForCollection[$metricClass] = array_map(static function (string $insightClass) use ($insightFactory, $collector, $config, $consoleOutput) {
                 if (! array_key_exists(Insight::class, class_implements($insightClass))) {
 
                     return $insightFactory->makeFrom(
                         $insightClass,
-                        $config
+                        $config,
+                        $consoleOutput
                     );
                 }
 
@@ -84,8 +92,8 @@ final class InsightCollectionFactory
     /**
      * Returns the `Insights` from the given metric class.
      *
-     * @param  string  $metricClass
-     * @param  array<string, array<string, string|array>>  $config
+     * @param string $metricClass
+     * @param array<string, array<string, string|array>> $config
      *
      * @return array<string>
      */

--- a/src/Domain/Insights/RuleDecorator.php
+++ b/src/Domain/Insights/RuleDecorator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace NunoMaduro\PhpInsights\Domain\Insights;
+
+use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+class RuleDecorator implements Insight, Rule
+{
+    /** @var \PHPStan\Rules\Rule */
+    private $rule;
+
+    private $errors = [];
+
+    /**
+     * RuleDecorator constructor.
+     *
+     * @param \PHPStan\Rules\Rule $rule
+     */
+    public function __construct(\PHPStan\Rules\Rule $rule)
+    {
+        $this->rule = $rule;
+    }
+
+    /**
+     * Checks if the insight detects an issue.
+     *
+     * @return bool
+     */
+    public function hasIssue(): bool
+    {
+        return ! empty($this->errors);
+    }
+
+    /**
+     * Gets the title of the insight.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return "rule fail";
+    }
+
+    /**
+     * Get the class name of Insight used.
+     *
+     * @return string
+     */
+    public function getInsightClass(): string
+    {
+        return get_class($this->rule);
+    }
+
+    /**
+     * @return string Class implementing \PhpParser\Node
+     */
+    public function getNodeType(): string
+    {
+        return $this->rule->getNodeType();
+    }
+
+    /**
+     * @param \PhpParser\Node $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return array<string|\PHPStan\Rules\RuleError> errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = $this->rule->processNode($node, $scope);
+
+        $this->errors += $errors;
+
+        return $errors;
+    }
+}

--- a/src/Domain/Insights/Sniff.php
+++ b/src/Domain/Insights/Sniff.php
@@ -6,6 +6,7 @@ namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
+use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Exceptions\SniffClassNotFound;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 use SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff;
@@ -72,7 +73,16 @@ final class Sniff implements Insight, HasDetails
     public function getDetails(): array
     {
         return array_map(static function (Error $error) {
-            return $error->getFileInfo()->getRealPath() . ':' . $error->getLine() . ': ' . $error->getMessage();
+            $details = Details::make()
+                ->withOriginal($error)
+                ->withLine($error->getLine())
+                ->withMessage($error->getMessage());
+
+            if (($file = $error->getFileInfo()->getRealPath()) !== false) {
+                $details->withFile($file);
+            }
+
+            return $details;
         }, $this->errors);
     }
 

--- a/src/Domain/Metrics/Code/Code.php
+++ b/src/Domain/Metrics/Code/Code.php
@@ -28,6 +28,7 @@ use PHP_CodeSniffer\Standards\PSR2\Sniffs\ControlStructures\SwitchDeclarationSni
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\EvalSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff;
 use PHP_CodeSniffer\Standards\Zend\Sniffs\Debug\CodeAnalyzerSniff;
+use PHPStan\Rules\Cast\UselessCastRule;
 use SlevomatCodingStandard\Sniffs\Arrays\DisallowImplicitArrayCreationSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\DisallowContinueWithoutIntegerOperandInSwitchSniff;
@@ -109,6 +110,7 @@ final class Code implements HasValue, HasInsights
             UselessSemicolonSniff::class,
             DeclareStrictTypesSniff::class,
             DuplicateAssignmentToVariableSniff::class,
+            UselessCastRule::class,
             // FullyQualifiedExceptionsSniff::class,
             // FullyQualifiedGlobalConstantsSniff::class,
         ];

--- a/src/Domain/PhpStanContainer.php
+++ b/src/Domain/PhpStanContainer.php
@@ -4,7 +4,7 @@ namespace NunoMaduro\PhpInsights\Domain;
 
 use PHPStan\DependencyInjection\ContainerFactory;
 
-class PhpstanContainer
+class PhpStanContainer
 {
     /**
      * @var \Symfony\Component\DependencyInjection\Container

--- a/src/Domain/PhpstanContainer.php
+++ b/src/Domain/PhpstanContainer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NunoMaduro\PhpInsights\Domain;
+
+use PHPStan\DependencyInjection\ContainerFactory;
+
+class PhpstanContainer
+{
+    /**
+     * @var \Symfony\Component\DependencyInjection\Container
+     */
+    private static $container;
+
+    /**
+     * @param $currentWorkingDirectory
+     * @return \Nette\DI\Container
+     */
+    public static function make($currentWorkingDirectory): \Nette\DI\Container
+    {
+        if (self::$container === null) {
+            $factory = new ContainerFactory($currentWorkingDirectory);
+
+            $container = $factory->create(
+                sys_get_temp_dir() . '/phpstan',
+                [],
+                []
+            );
+
+            self::$container = $container;
+        }
+
+        return self::$container;
+    }
+}

--- a/tests/Application/Console/Formatters/ConsoleTest.php
+++ b/tests/Application/Console/Formatters/ConsoleTest.php
@@ -2,30 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Tests\Application\Console;
+namespace Tests\Application\Console\Formatters;
 
-use NunoMaduro\PhpInsights\Application\Console\Style;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\Console;
 use Tests\TestCase;
 
-final class StyleTest extends TestCase
+final class ConsoleTest extends TestCase
 {
     public function testStringHasCorrectLengthWhenOneDigitValue(): void
     {
-        $percentageString = self::invokeStaticMethod(Style::class, 'getPercentageAsString', [1]);
+        $percentageString = self::invokeStaticMethod(Console::class, 'getPercentageAsString', [1]);
 
         self::assertEquals(5, strlen($percentageString));
     }
 
     public function testStringHasCorrectLengthWhenTwoDigitValue(): void
     {
-        $percentageString = self::invokeStaticMethod(Style::class, 'getPercentageAsString', [10]);
+        $percentageString = self::invokeStaticMethod(Console::class, 'getPercentageAsString', [10]);
 
         self::assertEquals(5, strlen($percentageString));
     }
 
     public function testStringHasCorrectLengthWhenThreeDigitValue(): void
     {
-        $percentageString = self::invokeStaticMethod(Style::class, 'getPercentageAsString', [100]);
+        $percentageString = self::invokeStaticMethod(Console::class, 'getPercentageAsString', [100]);
 
         self::assertEquals(5, strlen($percentageString));
     }

--- a/tests/Domain/Insights/Composer/ComposerMustBeValidTest.php
+++ b/tests/Domain/Insights/Composer/ComposerMustBeValidTest.php
@@ -17,9 +17,17 @@ final class ComposerMustBeValidTest extends TestCase
 
         self::assertTrue($insight->hasIssue());
         self::assertIsArray($insight->getDetails());
-        self::assertContains('composer.json: The property name is required', $insight->getDetails());
-        self::assertContains('composer.json: The property description is required', $insight->getDetails());
-        self::assertContains('composer.json: No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.', $insight->getDetails());
+
+        $messages = [];
+        /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */
+        foreach ($insight->getDetails() as $detail) {
+            self::assertEquals('composer.json', $detail->getFile());
+            $messages[] = $detail->getMessage();
+        }
+
+        self::assertContains('The property name is required', $messages);
+        self::assertContains('The property description is required', $messages);
+        self::assertContains('No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.', $messages);
     }
 
     public function testComposerIsValid(): void

--- a/tests/Domain/Insights/CyclomaticComplexityIsHighTest.php
+++ b/tests/Domain/Insights/CyclomaticComplexityIsHighTest.php
@@ -44,8 +44,20 @@ final class CyclomaticComplexityIsHighTest extends TestCase
         self::assertTrue($insight->hasIssue());
         self::assertIsArray($insight->getDetails());
         self::assertCount(2, $insight->getDetails());
-        self::assertContains('LittleToComplexClass.php: 6 cyclomatic complexity', $insight->getDetails());
-        self::assertContains('VeryMuchToComplexClass.php: 13 cyclomatic complexity', $insight->getDetails());
+
+        $messages = [];
+        $files = [];
+        /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */
+        foreach ($insight->getDetails() as $detail) {
+            $messages[] = $detail->getMessage();
+            $files[] = $detail->getFile();
+        }
+
+        self::assertContains('LittleToComplexClass.php', $files);
+        self::assertContains('6 cyclomatic complexity', $messages);
+
+        self::assertContains('VeryMuchToComplexClass.php', $files);
+        self::assertContains('13 cyclomatic complexity', $messages);
     }
 
     public function testClassWeCanConfigureTheMaxComplexity(): void
@@ -70,7 +82,19 @@ final class CyclomaticComplexityIsHighTest extends TestCase
         self::assertTrue($insight->hasIssue());
         self::assertIsArray($insight->getDetails());
         self::assertCount(1, $insight->getDetails());
-        self::assertNotContains('LittleToComplexClass.php: 6 cyclomatic complexity', $insight->getDetails());
-        self::assertContains('VeryMuchToComplexClass.php: 13 cyclomatic complexity', $insight->getDetails());
+
+        $messages = [];
+        $files = [];
+        /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */
+        foreach ($insight->getDetails() as $detail) {
+            $messages[] = $detail->getMessage();
+            $files[] = $detail->getFile();
+        }
+
+        self::assertNotContains('LittleToComplexClass.php', $files);
+        self::assertNotContains('6 cyclomatic complexity', $messages);
+
+        self::assertContains('VeryMuchToComplexClass.php', $files);
+        self::assertContains('13 cyclomatic complexity', $messages);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 use ReflectionException;
+use Symfony\Component\Console\Output\NullOutput;
 use Tests\Fakes\FakeFileRepository;
 
 abstract class TestCase extends BaseTestCase
@@ -90,7 +91,8 @@ abstract class TestCase extends BaseTestCase
         return $insightCollectionFactory->get(
             MetricsFinder::find(),
             $config,
-            $dir
+            $dir,
+            new NullOutput
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #165

This PR adds support for phpstan.
It takes the same approach as the sniffers and actually uses the same file processor class.

The PR is based off the new formatter branch #201, as I didn't want to implement the `HasDetails` interface twice. So it is on hold until the formatter branch is merged in.


- [ ] Some refactoring of `InsightFactory` is required, as the naming in there and so on is kinda random now, as it also handles rules from phpstan and not only sniffs.
- [ ] Again refactoring, but this time look at the `RuleDecorator` class.
- [ ] Maybe add some phpstan rules (currently only 1 is added) (any help on this appreciated!)
- [ ] Add docs about phpstan...
- [ ] And if not too lazy. then tests


resolves: #165
