### PR TITLE
Bump Symplify dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "sensiolabs/security-checker": "^6.0",
         "symfony/console": "^4.2",
         "symfony/finder": "^4.2",
-        "symplify/coding-standard": "^6.0",
-        "symplify/easy-coding-standard": "^6.0",
-        "symplify/package-builder": "^6.0"
+        "symplify/coding-standard": "^6.0.4",
+        "symplify/easy-coding-standard": "^6.0.4",
+        "symplify/package-builder": "^6.0.4"
     },
     "require-dev": {
         "illuminate/console": "^5.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #215

This fixes eventual deprecation errors coming from the Symplify dependencies.
Version 6.0.0 of the Symplify dependencies still uses deprecated features from the Package Builder package, which triggers an error and adds a sleep.
