### PR TITLE
Remove the art folder when requiring the package.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,4 @@ RELEASE.md
 /docs
 /tests
 /stubs
+/art

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@ RELEASE.md export-ignore
 docker export-ignore
 docs export-ignore
 tests export-ignore
+art export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| Fixed tickets | #224

<!--
- Stops the 'art' folder being pulled in when the package is pulled in via Composer.
-->
