### PR TITLE
Add more file/folder to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@ RELEASE.md export-ignore
 docker export-ignore
 docs export-ignore
 tests export-ignore
+art export-ignore


### PR DESCRIPTION
Add art folder to the ignoring list.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #224 

- This PR is to remove the art folder from the package files when people use it in their projects.
