### PR TITLE
Fix copy logo script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     ],
     "scripts": {
         "website:copy-changelog": "@php -r \"copy('CHANGELOG.md', 'docs/changelog.md');\"",
-        "website:copy-logo": "@php -r \"copy('art/logo_mixed.gif', 'docs/.vuepress/public/logo.gif');\"",
+        "website:copy-logo": "@php -r \"(is_dir('docs/.vuepress/public') || mkdir('docs/.vuepress/public')) && copy('art/logo_mixed.gif', 'docs/.vuepress/public/logo.gif');\"",
         "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/set/clean-code.yaml",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

The `docs/.vuepress/public` directory doesn't exist due to https://github.com/nunomaduro/phpinsights/pull/228. The `website:copy-logo` script will raise an error.

```bash
> @php -r "copy('CHANGELOG.md', 'docs/changelog.md');"
> @php -r "copy('art/logo_mixed.gif', 'docs/.vuepress/public/logo.gif');"
PHP Warning:  copy(docs/.vuepress/public/logo.gif): failed to open stream: No such file or directory in Command line code on line 1
PHP Stack trace:
PHP   1. {main}() Command line code:0
PHP   2. copy() Command line code:1
```

To avoid this error, we can simply check whether this directory exists and then create if it doesn't exist.

By the way, there are some merged and unused branches that should be deleted to fresh the repository. You may configure github to automatically delete branch after merging for convenience.


