### PR TITLE
Lumen compatability

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -28,6 +28,28 @@ Then, use the `insights` Artisan command:
 php artisan insights
 ```
 
+## Within Lumen
+
+Because we cannot use Artisan's publish command within a Lumen project you must manually copy the config file into your project:
+
+```bash
+cp vendor/nunomaduro/phpinsights/stubs/laravel.php config/insights.php
+```
+
+Then register the `phpinsights` provider and load the configuration into the application within your `bootstrap/app.php` file:
+
+```php
+$app->register(\NunoMaduro\PhpInsights\Application\Adapters\Laravel\InsightsServiceProvider::class);
+$app->configure('insights');
+```
+
+And setup is done, so you can now run `phpinsights` with the following command:
+
+```bash
+php artisan insights
+```
+
+
 ## With Docker
 
 You can also use `phpinsights` via Docker:

--- a/src/Application/Adapters/Laravel/InsightsServiceProvider.php
+++ b/src/Application/Adapters/Laravel/InsightsServiceProvider.php
@@ -22,9 +22,11 @@ final class InsightsServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->publishes([
-            __DIR__ . '/../../../../stubs/laravel.php' => $this->app->configPath('insights.php'),
-        ], 'config');
+        if ($this->app instanceof \Illuminate\Contracts\Foundation\Application) {
+            $this->publishes([
+                __DIR__.'/../../../../stubs/laravel.php' => $this->app->configPath('insights.php'),
+            ], 'config');
+        }
 
         $this->commands([
             InsightsCommand::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| Fixed tickets | #235 

Following the conversion in #235 this PR updates the Laravel service provider to detect when it is being used in a Lumen application and avoid calling `$this->publishes` as the publish command is not available.

We could potentially make a separate Lumen service provider if preferred.

With the above changes in mind, I also updated the documentation to provide steps for install phpinsights in a Lumen app.