### PR TITLE
fix: removes broken sniff `EmptyCommentSniff`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,6 +24,7 @@ parameters:
         - '#Access to an undefined property PHP_CodeSniffer\\Config::\$standards.#'
         - '#Access to an undefined property PHP_CodeSniffer\\Sniffs\\Sniff::\$#'
         - '#NunoMaduro\\PhpInsights\\Application\\Console\\Formatters\\Json has an unused parameter \$input#'
+        - '#In method "NunoMaduro\\PhpInsights\\Domain\\File::process", caught "Throwable" must be rethrown#'
     autoload_files:
         - %rootDir%/../../squizlabs/php_codesniffer/autoload.php
     reportUnmatchedIgnoredErrors: false

--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -111,7 +111,11 @@ final class File extends BaseFile
 
                 $this->reportActiveSniffClass($sniff);
 
-                $sniff->process($this, $stackPtr);
+                try {
+                    $sniff->process($this, $stackPtr);
+                } catch (\Throwable $e) {
+                    $this->addError('Unparsable php code: syntax error or wrong phpdocs.', $stackPtr, $token['code']);
+                }
             }
         }
 

--- a/src/Domain/Metrics/Code/Comments.php
+++ b/src/Domain/Metrics/Code/Comments.php
@@ -10,6 +10,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\HasPercentage;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasValue;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\FixmeSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff;
+use SlevomatCodingStandard\Sniffs\Commenting\EmptyCommentSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\ForbiddenCommentsSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessInheritDocCommentSniff;
@@ -39,7 +40,7 @@ final class Comments implements HasValue, HasPercentage, HasInsights
     public function getInsights(): array
     {
         return [
-            // EmptyCommentSniff::class,
+            EmptyCommentSniff::class,
             // FullyQualifiedClassNameInAnnotationSniff::class,
             NullableTypeForNullDefaultValueSniff::class,
             FixmeSniff::class,

--- a/src/Domain/Metrics/Code/Comments.php
+++ b/src/Domain/Metrics/Code/Comments.php
@@ -10,7 +10,6 @@ use NunoMaduro\PhpInsights\Domain\Contracts\HasPercentage;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasValue;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\FixmeSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff;
-use SlevomatCodingStandard\Sniffs\Commenting\EmptyCommentSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\ForbiddenCommentsSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessInheritDocCommentSniff;
@@ -40,7 +39,7 @@ final class Comments implements HasValue, HasPercentage, HasInsights
     public function getInsights(): array
     {
         return [
-            EmptyCommentSniff::class,
+            // EmptyCommentSniff::class,
             // FullyQualifiedClassNameInAnnotationSniff::class,
             NullableTypeForNullDefaultValueSniff::class,
             FixmeSniff::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #62 #59 and others...

This sniff `EmptyCommentSniff` doesn't work well in legacy projects. Tried to contact the owner of the project here https://github.com/slevomat/coding-standard/pull/688, but the owner doesn't have to have this sniff fixed.

The only solution, for now, is remove the sniff. What do you guys think?