### PR TITLE
[Fix] Silence warnings

### DIFF
--- a/phpinsights.php
+++ b/phpinsights.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\NoSilencedErrorsSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff;
 
 return [
@@ -58,6 +59,12 @@ return [
             'exclude' => [
                 'src/Domain/Reflection.php',
                 'src/Domain/Details.php',
+            ],
+        ],
+        NoSilencedErrorsSniff::class => [
+            'exclude' => [
+                'src/Domain/Analyser.php',
+                'src/Domain/File.php',
             ],
         ],
     ],

--- a/src/Domain/Analyser.php
+++ b/src/Domain/Analyser.php
@@ -71,7 +71,7 @@ final class Analyser
     private function analyseFile(Collector $collector, string $filename): void
     {
         $buffer = (string) \file_get_contents($filename);
-        $tokens = \token_get_all($buffer);
+        $tokens = @\token_get_all($buffer);
         $numTokens = \count($tokens);
 
         unset($buffer);

--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -112,7 +112,7 @@ final class File extends BaseFile
                 $this->reportActiveSniffClass($sniff);
 
                 try {
-                    $sniff->process($this, $stackPtr);
+                    @$sniff->process($this, $stackPtr);
                 } catch (\Throwable $e) {
                     $this->addError('Unparsable php code: syntax error or wrong phpdocs.', $stackPtr, $token['code']);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Fixed tickets | #59 

This PR removes the warnings thrown by PHP when a Sniff hits invalid code.
