### PR TITLE
update docs 

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -123,3 +123,7 @@ composer require --dev bamarni/composer-bin-plugin
 composer bin phpinsights require nunomaduro/phpinsights
 ./vendor/bin/phpinsights
 ```
+
+## PHPStorm: link files from console
+
+If you want to have a clickable link in your PHPStorm terminal to the file with an issue you can use [awesome console plugin](https://plugins.jetbrains.com/plugin/7677-awesome-console). This will make all file links clickable and even respects the line.

--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -104,8 +104,9 @@ For example, to increase the line length limits:
     ]
 ```
 
-You can also configure the `exclude` parameter on each insight, to disallow an
-insight on a specific file.
+You can also configure the `exclude` parameter on each sniff, to disallow a
+sniff on a specific file.
+This **only** works for sniffs and not for insights.
 
 For example, to remove "Unused Parameters" Insight only for some file:
 ```php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #237 & #240

update the docs to hint that exclude only works for sniffs and recommend PHPStorm plugin for file links.
