### PR TITLE
[HOTFIX] missing dependency illuminate str

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ script:
       composer run phpunit:test
       composer run insights -- --disable-security-check
     fi
-
+  - rm -rf vendor/
+  - composer install --no-dev
+  - composer run insights -- --disable-security-check
 jobs:
   include:
     - stage: build docker image

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
         "composer/composer": "^1.7",
+        "illuminate/support": "^5.6|^6.0",
         "league/container": "^3.2",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
         "phploc/phploc": "^5.0",
@@ -28,7 +29,6 @@
     },
     "require-dev": {
         "illuminate/console": "^5.8",
-        "illuminate/support": "^5.8",
         "localheinz/phpstan-rules": "^0.10.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.11",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
         "composer/composer": "^1.7",
-        "illuminate/support": "^5.6|^6.0",
         "league/container": "^3.2",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
         "phploc/phploc": "^5.0",
@@ -29,6 +28,7 @@
     },
     "require-dev": {
         "illuminate/console": "^5.8",
+        "illuminate/support": "^5.8",
         "localheinz/phpstan-rules": "^0.10.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.11",

--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
-use Illuminate\Support\Str;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Details;
@@ -123,11 +122,11 @@ final class SniffDecorator implements Sniff, Insight, HasDetails
         $path = explode('\\', $sniffClass);
         $name = (string) array_pop($path);
 
-        $name = Str::before($name, 'Sniff');
+        $name = str_replace('Sniff', '', $name);
 
-        return Str::ucfirst(
-            trim(
-                Str::lower(
+        return ucfirst(
+            mb_strtolower(
+                trim(
                     (string) preg_replace(
                         '/(?<!\ )[A-Z]/',
                         ' $0',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

With latest change, phpinsights as standalone doesn't work

```
[ARCHITECTURE] 82.6 pts within 103 files

Classes ........................................................... 78.6 %
Interfaces ........................................................ 13.6 %
Globally ........................................................... 7.8 %
Traits ............................................................. 0.0 %

[MISC] 97.8 pts on coding style and 0 security issues encountered
PHP Fatal error:  Uncaught Error: Class 'Illuminate\Support\Str' not found in /home/barth/Projects/phpinsights/src/Domain/Insights/SniffDecorator.php:126
Stack trace:
#0 /home/barth/Projects/phpinsights/src/Application/Console/Formatters/Console.php(291): NunoMaduro\PhpInsights\Domain\Insights\SniffDecorator->getTitle()

```

So I added illuminate/support in direct dependencies.