### PR TITLE
Add package publish command for laravel users to the readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ composer require nunomaduro/phpinsights --dev
 ./vendor/bin/phpinsights
 
 # For Laravel:
+First, publish the configuration file:
+php artisan vendor:publish --provider="NunoMaduro\PhpInsights\Application\Adapters\Laravel\InsightsServiceProvider"
+
+Then, use it:
 php artisan insights
 ```
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets |  none

This PR is meant to add a piece of small but useful information to the readme. For laravel users, you need to first publish the config file before using the package. If you don't, laravel will prompt you to by providing you with the `php artisan vendor:publish` command that will display all the current packages on your app as a list for you to select from. I believe this should immediately be pointed out in the readme so it becomes immediately obvious.
