### PR TITLE
Fix when generating a tag in docker hub (#278)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ jobs:
       php: 7.3
       env: COMPOSER_FLAGS=""
       script:
+        - rm -rf vendor/
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - export REPO=$DOCKER_USERNAME/phpinsights
         - docker build -f docker/Dockerfile -t $REPO:$TRAVIS_TAG .
         - docker tag $REPO:$TRAVIS_TAG $REPO:latest
-        - docker push $REPO
+        - docker push $REPO:$TRAVIS_TAG
+        - docker push $REPO:latest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #278 

Every time a new tag is deployed, it was not generated in the dockerhub according to github.

Now every time a new tag is deployed, a tag from the current version and a latest tag will be generated.

This resolves issue # 278

<!--
- Replace this comment by a description of what your PR is solving.
-->
