### PR TITLE
[Refact] configuration class

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use League\Container\Container;
 use League\Container\ReflectionContainer;
+use NunoMaduro\PhpInsights\Application\Injectors\Configuration;
 use NunoMaduro\PhpInsights\Application\Injectors\FileProcessors;
 use NunoMaduro\PhpInsights\Application\Injectors\InsightLoaders;
 use NunoMaduro\PhpInsights\Application\Injectors\Repositories;
@@ -12,6 +13,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\InsightLoader;
 
 return (static function () {
     $injectors = [
+        Configuration::class,
         Repositories::class,
         FileProcessors::class,
         InsightLoaders::class,

--- a/src/Application/Console/Analyser.php
+++ b/src/Application/Console/Analyser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Application\Console;
 
 use NunoMaduro\PhpInsights\Application\Console\Contracts\Formatter;
+use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Insights\InsightCollectionFactory;
 use NunoMaduro\PhpInsights\Domain\MetricsFinder;
 use NunoMaduro\PhpInsights\Domain\Results;
@@ -21,37 +22,42 @@ final class Analyser
     private $insightCollectionFactory;
 
     /**
+     * @var \NunoMaduro\PhpInsights\Domain\Configuration
+     */
+    private $config;
+
+    /**
      * Analyser constructor.
      *
      * @param \NunoMaduro\PhpInsights\Domain\Insights\InsightCollectionFactory $insightCollectionFactory
+     * @param \NunoMaduro\PhpInsights\Domain\Configuration $config
      */
-    public function __construct(InsightCollectionFactory $insightCollectionFactory)
-    {
+    public function __construct(
+        InsightCollectionFactory $insightCollectionFactory,
+        Configuration $config
+    ) {
         $this->insightCollectionFactory = $insightCollectionFactory;
+        $this->config = $config;
     }
 
     /**
      * Analyse the given dirs.
      *
      * @param Formatter $formatter
-     * @param array<string, array> $config
-     * @param string $dir
      * @param OutputInterface $consoleOutput
      *
      * @return  \NunoMaduro\PhpInsights\Domain\Results
      */
     public function analyse(
         Formatter $formatter,
-        array $config,
-        string $dir,
         OutputInterface $consoleOutput
     ): Results {
         $metrics = MetricsFinder::find();
 
         $insightCollection = $this->insightCollectionFactory
-            ->get($metrics, $config, $dir, $consoleOutput);
+            ->get($metrics, $consoleOutput);
 
-        $formatter->format($insightCollection, $dir, $metrics);
+        $formatter->format($insightCollection, $this->config->getDirectory(), $metrics);
 
         return $insightCollection->results();
     }

--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Application\Console\Commands;
 
-use NunoMaduro\PhpInsights\Application\ConfigResolver;
 use NunoMaduro\PhpInsights\Application\Console\Analyser;
 use NunoMaduro\PhpInsights\Application\Console\Formatters\FormatResolver;
 use NunoMaduro\PhpInsights\Application\Console\OutputDecorator;
 use NunoMaduro\PhpInsights\Application\Console\Style;
-use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
-use NunoMaduro\PhpInsights\Domain\Kernel;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,22 +25,13 @@ final class AnalyseCommand
     private $analyser;
 
     /**
-     * Holds an instance of the Files Repository.
-     *
-     * @var \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository
-     */
-    private $filesRepository;
-
-    /**
      * Creates a new instance of the Analyse Command.
      *
      * @param \NunoMaduro\PhpInsights\Application\Console\Analyser $analyser
-     * @param \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository $filesRepository
      */
-    public function __construct(Analyser $analyser, FilesRepository $filesRepository)
+    public function __construct(Analyser $analyser)
     {
         $this->analyser = $analyser;
-        $this->filesRepository = $filesRepository;
     }
 
     /**
@@ -67,24 +55,8 @@ final class AnalyseCommand
 
         $formatter = FormatResolver::resolve($input, $output, $consoleOutput);
 
-        $directory = $this->getDirectory($input);
-
-        $isRootAnalyse = true;
-        foreach (Kernel::getRequiredFiles() as $file) {
-            if (! file_exists($directory . DIRECTORY_SEPARATOR . $file)) {
-                $isRootAnalyse = false;
-                break;
-            }
-        }
-        $config = $this->getConfig($input, $directory);
-
-        if (! $isRootAnalyse) {
-            $config = $this->excludeGlobalInsights($config);
-        }
         $results = $this->analyser->analyse(
             $formatter,
-            $config,
-            $directory,
             $consoleOutput
         );
 
@@ -117,58 +89,5 @@ final class AnalyseCommand
         $consoleStyle->writeln('✨ See something that needs to be improved? <bold>Create an issue</bold> or send us a <bold>pull request</bold>: <title>https://github.com/nunomaduro/phpinsights</title>');
 
         return (int) $hasError;
-    }
-
-    /**
-     * Gets the config from the given input.
-     *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     * @param string $directory
-     *
-     * @return array<string, array>
-     */
-    private function getConfig(InputInterface $input, string $directory): array
-    {
-        /** @var string|null $configPath */
-        $configPath = $input->getOption('config-path');
-
-        if ($configPath === null && file_exists(getcwd() . DIRECTORY_SEPARATOR . 'phpinsights.php')) {
-            $configPath = getcwd() . DIRECTORY_SEPARATOR . 'phpinsights.php';
-        }
-
-        return ConfigResolver::resolve($configPath !== null && file_exists($configPath) ? require $configPath : [], $directory);
-    }
-
-    /**
-     * Gets the directory from the given input.
-     *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     *
-     * @return string
-     */
-    private function getDirectory(InputInterface $input): string
-    {
-        /** @var string $directory */
-        $directory = $input->getArgument('directory') ?? $this->filesRepository->getDefaultDirectory();
-
-        if ($directory[0] !== DIRECTORY_SEPARATOR && preg_match('~\A[A-Z]:(?![^/\\\\])~i', $directory) === 0) {
-            $directory = (string) getcwd() . DIRECTORY_SEPARATOR . $directory;
-        }
-
-        return $directory;
-    }
-
-    /**
-     * @param array<string, array> $config
-     *
-     * @return array<string, array>
-     */
-    private function excludeGlobalInsights(array $config): array
-    {
-        foreach (Kernel::getGlobalInsights() as $insight) {
-            $config['remove'][] = $insight;
-        }
-
-        return $config;
     }
 }

--- a/src/Application/Console/Commands/InvokableCommand.php
+++ b/src/Application/Console/Commands/InvokableCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Application\Console\Commands;
 
 use Symfony\Component\Console\Command\Command as BaseCommand;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -18,11 +19,11 @@ final class InvokableCommand extends BaseCommand
     /**
      * Creates a new instance of the Invokable Command.
      *
-     * @param  string  $name
-     * @param  callable  $callable
-     * @param  array<int, \Symfony\Component\Console\Input\InputArgument|\Symfony\Component\Console\Input\InputOption>  $definition
+     * @param string $name
+     * @param callable $callable
+     * @param InputDefinition $definition
      */
-    public function __construct(string $name, callable $callable, array $definition)
+    public function __construct(string $name, callable $callable, InputDefinition $definition)
     {
         parent::__construct($name);
 

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Application\Console\Definitions;
 
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
 /**
@@ -13,11 +14,11 @@ use Symfony\Component\Console\Input\InputOption;
 final class AnalyseDefinition
 {
     /**
-     * @return array<int, \Symfony\Component\Console\Input\InputOption|\Symfony\Component\Console\Input\InputArgument>
+     * @return InputDefinition
      */
-    public static function get(): array
+    public static function get(): InputDefinition
     {
-        return [
+        return new InputDefinition([
             new InputArgument(
                 'directory',
                 InputArgument::OPTIONAL,
@@ -70,6 +71,6 @@ final class AnalyseDefinition
                 'Format to output the result in [console, json, checkstyle]',
                 'console'
             ),
-        ];
+        ]);
     }
 }

--- a/src/Application/DirectoryResolver.php
+++ b/src/Application/DirectoryResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @internal
+ */
+final class DirectoryResolver
+{
+    public static function resolve(InputInterface $input): string
+    {
+        /** @var string $directory */
+        $directory = $input->getArgument('directory') ?? (string) getcwd();
+
+        if ($directory[0] !== DIRECTORY_SEPARATOR && preg_match('~\A[A-Z]:(?![^/\\\\])~i', $directory) === 0) {
+            $directory = (string) getcwd() . DIRECTORY_SEPARATOR . $directory;
+        }
+
+        return $directory;
+    }
+}

--- a/src/Application/Injectors/Configuration.php
+++ b/src/Application/Injectors/Configuration.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application\Injectors;
+
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\Console\Definitions\AnalyseDefinition;
+use NunoMaduro\PhpInsights\Application\DirectoryResolver;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+
+/**
+ * @internal
+ */
+final class Configuration
+{
+    /**
+     * Inject Configuration resolved into the container definitions.
+     *
+     * @return array<string, callable>
+     */
+    public function __invoke(): array
+    {
+        return [
+            \NunoMaduro\PhpInsights\Domain\Configuration::class => static function () {
+                $input = new ArgvInput();
+                // merge application default definition with analyse definition.
+                $definition = (new Application())->getDefinition();
+                $analyseDefinition = AnalyseDefinition::get();
+
+                $definition->addArguments($analyseDefinition->getArguments());
+                $definition->addOptions($analyseDefinition->getOptions());
+
+                $input->bind($definition);
+
+                $configPath = ConfigResolver::resolvePath($input);
+                $config = [];
+
+                if ($configPath !== '' && file_exists($configPath)) {
+                    $config = require $configPath;
+                }
+
+                return ConfigResolver::resolve($config, DirectoryResolver::resolve($input));
+            },
+        ];
+    }
+}

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Domain;
+
+use NunoMaduro\PhpInsights\Application\Adapters\Drupal\Preset as DrupalPreset;
+use NunoMaduro\PhpInsights\Application\Adapters\Laravel\Preset as LaravelPreset;
+use NunoMaduro\PhpInsights\Application\Adapters\Magento2\Preset as Magento2Preset;
+use NunoMaduro\PhpInsights\Application\Adapters\Symfony\Preset as SymfonyPreset;
+use NunoMaduro\PhpInsights\Application\Adapters\Yii\Preset as YiiPreset;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
+use NunoMaduro\PhpInsights\Domain\Contracts\Metric;
+use NunoMaduro\PhpInsights\Domain\Exceptions\InvalidConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @internal
+ */
+final class Configuration
+{
+    /**
+     * @var array<string>
+     */
+    private static $presets = [
+        DrupalPreset::class,
+        LaravelPreset::class,
+        SymfonyPreset::class,
+        YiiPreset::class,
+        Magento2Preset::class,
+        DefaultPreset::class,
+    ];
+
+    /**
+     * @var string
+     */
+    private $preset = 'default';
+
+    /**
+     * Directory to analyse.
+     *
+     * @var string
+     */
+    private $directory;
+
+    /**
+     * List of folder to exclude from analyse.
+     *
+     * @var array<string>
+     */
+    private $exclude;
+
+    /**
+     * List of insights added by metrics.
+     *
+     * @var array<string, array<string>>
+     */
+    private $add;
+
+    /**
+     * List of insights class to remove.
+     *
+     * @var array<string>
+     */
+    private $remove;
+
+    /**
+     * List of custom configuration by insight.
+     *
+     * @var array<string, array<string, string|int|array>>
+     */
+    private $config;
+
+    /**
+     * Configuration constructor.
+     *
+     * @param array<string, string|array> $config
+     */
+    public function __construct(array $config)
+    {
+        $this->resolveConfig($config);
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public function getAdd(): array
+    {
+        return $this->add;
+    }
+
+    /**
+     * @param string $metric
+     *
+     * @return array<string>
+     */
+    public function getAddedInsightsByMetric(string $metric): array
+    {
+        return array_key_exists($metric, $this->add)
+            ? $this->add[$metric]
+            : [];
+    }
+
+    /**
+     * @return array<string, array<string, string|int|array>>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param string $insight
+     *
+     * @return array<string, string|int|array>
+     */
+    public function getConfigForInsight(string $insight): array
+    {
+        return $this->config[$insight] ?? [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getDirectory(): string
+    {
+        return $this->directory;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getExclude(): array
+    {
+        return $this->exclude;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRemove(): array
+    {
+        return $this->remove;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPreset(): string
+    {
+        return $this->preset;
+    }
+
+    /**
+     * @param array<string, string|array> $config
+     */
+    private function resolveConfig(array $config): void
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'preset' => 'default',
+            'directory' => (string) getcwd(),
+            'exclude' => [],
+            'add' => [],
+            'remove' => [],
+            'config' => [],
+        ]);
+
+        $resolver->setAllowedValues('preset', array_map(static function (string $presetClass) {
+            return $presetClass::getName();
+        }, self::$presets));
+        $resolver->setAllowedValues('add', $this->validateAddedInsight());
+        $resolver->setAllowedValues('config', $this->validateConfigInsights());
+        $config = $resolver->resolve($config);
+
+        $this->preset = $config['preset'];
+        $this->directory = $config['directory'];
+        $this->exclude = $config['exclude'];
+        $this->add = $config['add'];
+        $this->remove = $config['remove'];
+        $this->config = $config['config'];
+    }
+
+    private function validateAddedInsight(): \Closure
+    {
+        return static function ($values) {
+            foreach ($values as $metric => $insights) {
+                if (! class_exists($metric) ||
+                    ! in_array(Metric::class, class_implements($metric), true)
+                ) {
+                    throw new InvalidConfiguration(sprintf(
+                        'Unable to use "%s" class as metric in section add.',
+                        $metric
+                    ));
+                }
+                if (! is_array($insights)) {
+                    throw new InvalidConfiguration(sprintf(
+                        'Added insights for metric "%s" should be an array.',
+                        $metric
+                    ));
+                }
+
+                foreach ($insights as $insight) {
+                    if (! class_exists($insight)) {
+                        throw new InvalidConfiguration(sprintf(
+                            'Unable to add "%s" insight, class doesn\'t exists.',
+                            $insight
+                        ));
+                    }
+                }
+            }
+            return true;
+        };
+    }
+
+    private function validateConfigInsights(): \Closure
+    {
+        return static function ($values) {
+            foreach (array_keys($values) as $insight) {
+                if (! class_exists((string) $insight)) {
+                    throw new InvalidConfiguration(sprintf(
+                        'Unable to config "%s" insight, class doesn\'t exists.',
+                        $insight
+                    ));
+                }
+            }
+            return true;
+        };
+    }
+}

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -195,7 +195,7 @@ final class Configuration
                 }
                 if (! is_array($insights)) {
                     throw new InvalidConfiguration(sprintf(
-                        'Added insights for metric "%s" should be an array.',
+                        'Added insights for metric "%s" should be in an array.',
                         $metric
                     ));
                 }

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -130,7 +130,7 @@ final class Configuration
     /**
      * @return array<string>
      */
-    public function getExclude(): array
+    public function getExcludes(): array
     {
         return $this->exclude;
     }
@@ -138,7 +138,7 @@ final class Configuration
     /**
      * @return array<string>
      */
-    public function getRemove(): array
+    public function getRemoves(): array
     {
         return $this->remove;
     }

--- a/src/Domain/Contracts/InsightLoader.php
+++ b/src/Domain/Contracts/InsightLoader.php
@@ -25,7 +25,7 @@ interface InsightLoader
      *
      * @param string $insightClass
      * @param string $dir
-     * @param array<string, string|array> $config Related to $insightClass
+     * @param array<string, int|string|array> $config Related to $insightClass
      *
      * @return \NunoMaduro\PhpInsights\Domain\Contracts\Insight
      */

--- a/src/Domain/Exceptions/InvalidConfiguration.php
+++ b/src/Domain/Exceptions/InvalidConfiguration.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Domain\Exceptions;
+
+/**
+ * @internal
+ */
+final class InvalidConfiguration extends \RuntimeException
+{
+}

--- a/src/Domain/Insights/InsightCollectionFactory.php
+++ b/src/Domain/Insights/InsightCollectionFactory.php
@@ -76,7 +76,7 @@ final class InsightCollectionFactory
             $insightsClasses = array_merge($insightsClasses, $this->getInsights($metricClass));
         }
 
-        $insightFactory = new InsightFactory($this->filesRepository, $dir, $insightsClasses, $this->config);
+        $insightFactory = new InsightFactory($this->filesRepository, $insightsClasses, $this->config);
         $insightsForCollection = [];
         foreach ($metrics as $metricClass) {
             $insightsForCollection[$metricClass] = array_map(function (string $insightClass) use ($insightFactory, $collector, $consoleOutput) {

--- a/src/Domain/Insights/InsightCollectionFactory.php
+++ b/src/Domain/Insights/InsightCollectionFactory.php
@@ -64,7 +64,7 @@ final class InsightCollectionFactory
         try {
             $files = array_map(static function (\SplFileInfo $file) {
                 return $file->getRealPath();
-            }, iterator_to_array($this->filesRepository->within($dir, $this->config->getExclude())->getFiles()));
+            }, iterator_to_array($this->filesRepository->within($dir, $this->config->getExcludes())->getFiles()));
         } catch (\InvalidArgumentException $exception) {
             throw new DirectoryNotFound($exception->getMessage(), 0, $exception);
         }
@@ -115,6 +115,6 @@ final class InsightCollectionFactory
         $insights = array_merge($insights, $toAdd);
 
         // Remove insights based on config.
-        return array_diff($insights, $this->config->getRemove());
+        return array_diff($insights, $this->config->getRemoves());
     }
 }

--- a/src/Domain/Insights/InsightFactory.php
+++ b/src/Domain/Insights/InsightFactory.php
@@ -55,17 +55,16 @@ final class InsightFactory
      * Creates a new instance of Insight Factory.
      *
      * @param \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository $filesRepository
-     * @param string $dir
      * @param array<string> $insightsClasses
      * @param \NunoMaduro\PhpInsights\Domain\Configuration $config
      */
-    public function __construct(FilesRepository $filesRepository, string $dir, array $insightsClasses, Configuration $config)
+    public function __construct(FilesRepository $filesRepository, array $insightsClasses, Configuration $config)
     {
         $this->filesRepository = $filesRepository;
-        $this->dir = $dir;
         $this->insightsClasses = $insightsClasses;
         $this->insightLoaders = Container::make()->get(InsightLoader::INSIGHT_LOADER_TAG);
         $this->config = $config;
+        $this->dir = $config->getDirectory();
     }
 
     /**

--- a/src/Domain/Insights/InsightFactory.php
+++ b/src/Domain/Insights/InsightFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
+use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Container;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight as InsightContract;
 use NunoMaduro\PhpInsights\Domain\Contracts\InsightLoader;
@@ -42,6 +43,11 @@ final class InsightFactory
      */
     private $insightLoaders;
 
+    /**
+     * @var \NunoMaduro\PhpInsights\Domain\Configuration
+     */
+    private $config;
+
     /** @var bool */
     private $ran = false;
 
@@ -51,20 +57,21 @@ final class InsightFactory
      * @param \NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository $filesRepository
      * @param string $dir
      * @param array<string> $insightsClasses
+     * @param \NunoMaduro\PhpInsights\Domain\Configuration $config
      */
-    public function __construct(FilesRepository $filesRepository, string $dir, array $insightsClasses)
+    public function __construct(FilesRepository $filesRepository, string $dir, array $insightsClasses, Configuration $config)
     {
         $this->filesRepository = $filesRepository;
         $this->dir = $dir;
         $this->insightsClasses = $insightsClasses;
         $this->insightLoaders = Container::make()->get(InsightLoader::INSIGHT_LOADER_TAG);
+        $this->config = $config;
     }
 
     /**
      * Creates a Insight from the given error class.
      *
      * @param string $errorClass
-     * @param array<string, array> $config
      * @param OutputInterface $consoleOutput
      *
      * @return InsightContract
@@ -73,10 +80,9 @@ final class InsightFactory
      */
     public function makeFrom(
         string $errorClass,
-        array $config,
         OutputInterface $consoleOutput
     ): InsightContract {
-        $this->runInsightCollector($config, $consoleOutput);
+        $this->runInsightCollector($consoleOutput);
 
         /** @var InsightContract $insight */
         foreach ($this->insights as $insight) {
@@ -89,13 +95,10 @@ final class InsightFactory
     }
 
     /**
-     * @param array<string, array> $config
      * @param \Symfony\Component\Console\Output\OutputInterface $consoleOutput
      */
-    private function runInsightCollector(
-        array $config,
-        OutputInterface $consoleOutput
-    ): void {
+    private function runInsightCollector(OutputInterface $consoleOutput): void
+    {
         if ($this->ran === true) {
             return;
         }
@@ -106,7 +109,7 @@ final class InsightFactory
         );
 
         // Add insights
-        $insights = $this->loadInsights($this->insightsClasses, $config);
+        $insights = $this->loadInsights($this->insightsClasses);
         $this->insights = $insights;
         $runner->addInsights($insights);
 
@@ -119,18 +122,21 @@ final class InsightFactory
      * Return instancied insights.
      *
      * @param array<string> $insights
-     * @param array<string, array> $config
      *
      * @return array<InsightContract>
      */
-    private function loadInsights(array $insights, array $config): array
+    private function loadInsights(array $insights): array
     {
         $insightsAdded = [];
         foreach ($insights as $insight) {
             /** @var InsightLoader $loader */
             foreach ($this->insightLoaders as $loader) {
                 if ($loader->support($insight)) {
-                    $insightsAdded[] = $loader->load($insight, $this->dir, $config['config'][$insight] ?? []);
+                    $insightsAdded[] = $loader->load(
+                        $insight,
+                        $this->dir,
+                        $this->config->getConfigForInsight($insight)
+                    );
                 }
             }
         }

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Tests\Application;
 
 use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Domain\Configuration;
+use NunoMaduro\PhpInsights\Domain\Exceptions\InvalidConfiguration;
 use NunoMaduro\PhpInsights\Domain\Exceptions\PresetNotFound;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Classes;
 use PHPUnit\Framework\TestCase;
 use SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class ConfigResolverTest extends TestCase
 {
@@ -80,26 +84,50 @@ final class ConfigResolverTest extends TestCase
 
         $finalConfig = ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
 
-        self::assertArrayHasKey('exclude', $finalConfig);
-        self::assertArrayHasKey('config', $finalConfig);
-        self::assertContains('my/path', $finalConfig['exclude']);
+        self::assertContains('my/path', $finalConfig->getExclude());
         // assert we don't replace the first value
-        self::assertContains('bower_components', $finalConfig['exclude']);
-        self::assertArrayHasKey(DocCommentSpacingSniff::class, $finalConfig['config']);
+        self::assertContains('bower_components', $finalConfig->getExclude());
+        self::assertArrayHasKey(DocCommentSpacingSniff::class, $finalConfig->getConfig());
         // assert we replace the config value
         self::assertEquals(
             2,
-            $finalConfig['config'][DocCommentSpacingSniff::class]['linesCountBetweenDifferentAnnotationsTypes']
+            $finalConfig->getConfigForInsight(DocCommentSpacingSniff::class)['linesCountBetweenDifferentAnnotationsTypes']
         );
     }
 
     public function testUnknownPresetThrowException(): void
     {
-        self::expectException(PresetNotFound::class);
-        self::expectExceptionMessage('UnknownPreset not found');
+        self::expectException(InvalidOptionsException::class);
 
         $config = ['preset' => 'UnknownPreset'];
 
+        ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
+    }
+
+    public function testUnknowMetricAddedThrowException(): void
+    {
+        self::expectException(InvalidConfiguration::class);
+        self::expectErrorMessage('Unable to use "say" class as metric in section add.');
+
+        $config = ['add' => ['say' => 'hello']];
+        ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
+    }
+
+    public function testKnownMetricAddedWithNonArrayValueThrowException(): void
+    {
+        self::expectException(InvalidConfiguration::class);
+        self::expectErrorMessage('Added insights for metric "' . Classes::class. '" should be in an array.');
+
+        $config = ['add' => [Classes::class => 'hello']];
+        ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
+    }
+
+    public function testAddUnknowClassThrowException(): void
+    {
+        self::expectException(InvalidConfiguration::class);
+        self::expectErrorMessage('Unable to add "hello" insight, class doesn\'t exists.');
+
+        $config = ['add' => [Classes::class => ['hello']]];
         ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
     }
 }

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -84,9 +84,9 @@ final class ConfigResolverTest extends TestCase
 
         $finalConfig = ConfigResolver::resolve($config, $this->baseFixturePath . 'ComposerWithoutRequire');
 
-        self::assertContains('my/path', $finalConfig->getExclude());
+        self::assertContains('my/path', $finalConfig->getExcludes());
         // assert we don't replace the first value
-        self::assertContains('bower_components', $finalConfig->getExclude());
+        self::assertContains('bower_components', $finalConfig->getExcludes());
         self::assertArrayHasKey(DocCommentSpacingSniff::class, $finalConfig->getConfig());
         // assert we replace the config value
         self::assertEquals(

--- a/tests/Domain/Insights/CyclomaticComplexityIsHighTest.php
+++ b/tests/Domain/Insights/CyclomaticComplexityIsHighTest.php
@@ -24,19 +24,11 @@ final class CyclomaticComplexityIsHighTest extends TestCase
 
     public function testClassHasToMuchCyclomaticComplexity(): void
     {
-        $analyser = new Analyser();
-
         $files = [
             __DIR__ . '/Fixtures/LittleToComplexClass.php',
             __DIR__ . '/Fixtures/VeryMuchToComplexClass.php',
         ];
 
-        $fileRepository = new FakeFileRepository($files);
-
-        $insightCollectionFactory = new InsightCollectionFactory(
-            $fileRepository,
-            $analyser
-        );
         $analyzer = new Analyser();
         $collector = $analyzer->analyse(__DIR__ . '/Fixtures/', $files);
         $insight = new CyclomaticComplexityIsHigh($collector, []);
@@ -62,19 +54,11 @@ final class CyclomaticComplexityIsHighTest extends TestCase
 
     public function testClassWeCanConfigureTheMaxComplexity(): void
     {
-        $analyser = new Analyser();
-
         $files = [
             __DIR__ . '/Fixtures/LittleToComplexClass.php',
             __DIR__ . '/Fixtures/VeryMuchToComplexClass.php',
         ];
 
-        $fileRepository = new FakeFileRepository($files);
-
-        $insightCollectionFactory = new InsightCollectionFactory(
-            $fileRepository,
-            $analyser
-        );
         $analyzer = new Analyser();
         $collector = $analyzer->analyse(__DIR__ . '/Fixtures/', $files);
         $insight = new CyclomaticComplexityIsHigh($collector, ['maxComplexity' => 10]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -84,14 +84,12 @@ abstract class TestCase extends BaseTestCase
 
         $insightCollectionFactory = new InsightCollectionFactory(
             $fileRepository,
-            $analyser
+            $analyser,
+            $config
         );
-
 
         return $insightCollectionFactory->get(
             MetricsFinder::find(),
-            $config,
-            $dir,
             new NullOutput
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

In order to fix this [comment](https://github.com/nunomaduro/phpinsights/pull/265#discussion_r324466057), I add a Configuration Class that carry config provided by user.

The Configuration class is resolved when container boot, so we can use DependencyInjection or container to retrieve configuration. 
So we don't have anymore the need to manually pass config everywhere we need it. 

As phpcsfixer came with it, I use [symfony/options-resolver](https://symfony.com/doc/current/components/options_resolver.hml) to improve configuration validation.

I think this refact is needed, because the config file is growing, and we should have a simpler way to validate it, and also retrieve it. 

WDYT ?