### PR TITLE
[Chore] bump version to v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v1.10.0]
+## [Unreleased]
 ### Added
 - Checkstyle formatter ([#271](https://github.com/nunomaduro/phpinsights/pull/271))
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phpinsights",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/src/Domain/Kernel.php
+++ b/src/Domain/Kernel.php
@@ -18,7 +18,7 @@ final class Kernel
     /**
      * The app version.
      */
-    public const VERSION = 'v1.8.0';
+    public const VERSION = 'v1.9.0';
 
     /**
      * Bootstraps the usage of the package.


### PR DESCRIPTION
Looks we we forgot to bump the version to v1.9.0 :) 

Also the changelog was referencing a version we haven't released yet, so I changed it to the support `Unreleased` tag from Keep A Changelog