### PR TITLE
Fix laravel configuration resolution - #286

### DIFF
--- a/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
+++ b/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
@@ -42,7 +42,9 @@ final class InsightsCommand extends Command
             throw new \RuntimeException('Container should be League Container instance');
         }
 
-        $container->add(Configuration::class, $configuration);
+        $configurationDefinition = $container->extend(Configuration::class);
+        $configurationDefinition->setConcrete($configuration);
+
         $analyseCommand = $container->get(AnalyseCommand::class);
 
         $output = (new Reflection($this->output))->get('output');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #286 

When we add a service into container, it is not replaced if it was precedently defined.
So we need to replace concrete class of definition. 

Ping @akosglue 