### PR TITLE
Improve/progress bar

### DIFF
--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -6,10 +6,9 @@ namespace NunoMaduro\PhpInsights\Domain;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\FileProcessor as FileProcessorContract;
 use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
-use SplFileInfo;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal
@@ -71,34 +70,28 @@ final class Runner
 
         // Create progress bar
         $progressBar = $this->createProgressBar(count($files));
+        $progressBar->setMessage('');
         $progressBar->start();
 
         /** @var SplFileInfo $file */
         foreach ($files as $file) {
             // Output file name if verbose
             if ($this->output->isVerbose()) {
-                $this->output->writeln(" {$file->getRealPath()}");
+                $progressBar->setMessage(' - ' . $file->getRelativePathname());
             }
 
             $this->processFile($file);
             $progressBar->advance();
         }
+
+        if ($this->output->isVerbose()) {
+            $progressBar->setMessage(PHP_EOL . '<info>Analyse Completed !</info>');
+        }
+        $progressBar->finish();
     }
 
     private function processFile(SplFileInfo $file): void
     {
-        if (! ($file instanceof SymfonySplFileInfo)) {
-            $path = $file->getPath()
-                . DIRECTORY_SEPARATOR
-                . $file->getFilename();
-
-            $file = new SymfonySplFileInfo(
-                $path,
-                $file->getPath(),
-                $path
-            );
-        }
-
         /** @var FileProcessorContract $fileProcessor */
         foreach ($this->filesProcessors as $fileProcessor) {
             $fileProcessor->processFile($file);
@@ -113,6 +106,11 @@ final class Runner
         $progressCharacter = '';
         $barCharacter = '▓'; // dark shade character \u2593
 
+        $format = ProgressBar::getFormatDefinition($this->getProgressFormat());
+        $format .= PHP_EOL . '%message%';
+        ProgressBar::setFormatDefinition('phpinsight', $format);
+        $progressBar->setFormat('phpinsight');
+
         if ('\\' !== \DIRECTORY_SEPARATOR
             || 'Hyper' === getenv('TERM_PROGRAM')) {
             $progressBar->setEmptyBarCharacter($emptyBarCharacter);
@@ -121,5 +119,20 @@ final class Runner
         }
 
         return $progressBar;
+    }
+
+    private function getProgressFormat(): string
+    {
+        switch ($this->output->getVerbosity()) {
+            // OutputInterface::VERBOSITY_QUIET: display is disabled anyway
+            case OutputInterface::VERBOSITY_VERBOSE:
+                return 'verbose';
+            case OutputInterface::VERBOSITY_VERY_VERBOSE:
+                return 'very_verbose';
+            case OutputInterface::VERBOSITY_DEBUG:
+                return 'debug';
+            default:
+                return 'normal';
+        }
     }
 }

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -70,7 +70,7 @@ final class Runner
         }
 
         // Create progress bar
-        $progressBar = new ProgressBar($this->output, count($files));
+        $progressBar = $this->createProgressBar(count($files));
         $progressBar->start();
 
         /** @var SplFileInfo $file */
@@ -103,5 +103,23 @@ final class Runner
         foreach ($this->filesProcessors as $fileProcessor) {
             $fileProcessor->processFile($file);
         }
+    }
+
+    private function createProgressBar(int $max = 0): ProgressBar
+    {
+        $progressBar = new ProgressBar($this->output, $max);
+
+        $emptyBarCharacter = '░'; // light shade character \u2591
+        $progressCharacter = '';
+        $barCharacter = '▓'; // dark shade character \u2593
+
+        if ('\\' !== \DIRECTORY_SEPARATOR
+            || 'Hyper' === getenv('TERM_PROGRAM')) {
+            $progressBar->setEmptyBarCharacter($emptyBarCharacter);
+            $progressBar->setProgressCharacter($progressCharacter);
+            $progressBar->setBarCharacter($barCharacter);
+        }
+
+        return $progressBar;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I noticed the progress bar is different from v1.9.0 to master version.

After investigating, it appeared when we dropped ECS dependency. In fact, ECS use the SymfonyStyle class to create a ProgressBar, that change default display of progress bar: https://github.com/symfony/console/blob/master/Style/SymfonyStyle.php#L331-L339

So I restored this output style for progress bar.

In the second commit, I tried to explore how we can display correctly message without break the progress bar output.

Here the render:
![phpinsights-progress-bar](https://user-images.githubusercontent.com/3168281/67144013-260b9e80-f272-11e9-9571-7f9614bc089e.gif)

WDYT ? 
