### PR TITLE
Fix analyse on one file

### DIFF
--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -56,7 +56,10 @@ final class LocalFilesRepository implements FilesRepository
     public function within(string $path, array $exclude = []): FilesRepository
     {
         if (! is_dir($path) && is_file($path)) {
-            $this->finder->append([$path]);
+            $pathInfo = pathinfo($path);
+            $this->finder = Finder::create()
+                ->in($pathInfo['dirname'])
+                ->name($pathInfo['basename']);
 
             return $this;
         }

--- a/tests/Infrastructure/Repositories/LocalFilesRepositoryTest.php
+++ b/tests/Infrastructure/Repositories/LocalFilesRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Tests\Infrastructure\Repositories;
 
 use NunoMaduro\PhpInsights\Infrastructure\Repositories\LocalFilesRepository;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Tests\TestCase;
 
 final class LocalFilesRepositoryTest extends TestCase
@@ -74,10 +75,10 @@ final class LocalFilesRepositoryTest extends TestCase
 
         $repository = new LocalFilesRepository($finder);
         $repository->within(__DIR__ . '/Fixtures/FileToInspect.php');
-        $files = iterator_to_array($repository->getFiles());
+        $files = iterator_to_array($repository->getFiles(), false);
 
         self::assertCount(1, $files);
-        self::assertInstanceOf(\SplFileInfo::class, $files[0]);
+        self::assertInstanceOf(SplFileInfo::class, $files[0]);
         self::assertStringContainsString('/Fixtures/FileToInspect.php', $files[0]->getRealPath());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Bug introduced in #291. When we use `append` in Finder, it return an \AppendIterator fill of `\SplFileInfo` instead of `Symfony\Component\Finder\SplFileInfo`. 

