### PR TITLE
Fix display tip repo when format is console

### DIFF
--- a/src/Application/Console/Commands/AnalyseCommand.php
+++ b/src/Application/Console/Commands/AnalyseCommand.php
@@ -45,7 +45,8 @@ final class AnalyseCommand
     public function __invoke(InputInterface $input, OutputInterface $output): int
     {
         $consoleOutput = $output;
-        if ($consoleOutput instanceof ConsoleOutputInterface) {
+        if ($consoleOutput instanceof ConsoleOutputInterface
+            && $input->getOption('format') !== 'console') {
             $consoleOutput = $consoleOutput->getErrorOutput();
             $consoleOutput->setDecorated($output->isDecorated());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I noticed when display all issues, sometimes the 'tip' for send issue or pull request appear in issues flow.

![image](https://user-images.githubusercontent.com/3168281/67631003-a17fd800-f890-11e9-92ce-341cb4ac028e.png)

Fixed by not using errorOuput when use consoleFormatter
