### PR TITLE
fix: removes duplicated no empty comment sniff

### DIFF
--- a/docs/insights/code.md
+++ b/docs/insights/code.md
@@ -380,12 +380,6 @@ This sniff looks for duplicate assignments to a variable.
 
 **Insight Class**: `SlevomatCodingStandard\Sniffs\Variables\DuplicateAssignmentToVariableSniff`
 
-## Empty comment <Badge text="^1.0"/> <Badge text="Code\Comments" type="warn"/>
-
-This sniff reports empty comments.
-
-**Insight Class**: `SlevomatCodingStandard\Sniffs\Commenting\EmptyCommentSniff`
-
 ## Nullable type for null default value <Badge text="^1.0"/> <Badge text="Code\Comments" type="warn"/>
 
 This sniff checks whether the nullablity `?` symbol is present before each nullable and optional parameter (which are marked as `= null`)

--- a/src/Domain/Metrics/Code/Comments.php
+++ b/src/Domain/Metrics/Code/Comments.php
@@ -19,7 +19,6 @@ use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer;
-use SlevomatCodingStandard\Sniffs\Commenting\EmptyCommentSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\ForbiddenCommentsSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessInheritDocCommentSniff;
@@ -49,7 +48,6 @@ final class Comments implements HasValue, HasPercentage, HasInsights
     public function getInsights(): array
     {
         return [
-            EmptyCommentSniff::class,
             // FullyQualifiedClassNameInAnnotationSniff::class,
             NullableTypeForNullDefaultValueSniff::class,
             FixmeSniff::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

This pull request fixes the fact that the EmptyComment sniff is duplicated with NoEmptyComment from php cs fixer.
