### PR TITLE
fix: removes void return fixer from laravel preset

### DIFF
--- a/src/Application/Adapters/Laravel/Preset.php
+++ b/src/Application/Adapters/Laravel/Preset.php
@@ -10,6 +10,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineGlobalConstants;
 use NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 
 /**
  * @internal
@@ -41,7 +42,7 @@ final class Preset implements PresetContract
                 // ...
             ],
             'remove' => [
-                // ...
+                VoidReturnFixer::class,
             ],
             'config' => [
                 ForbiddenDefineGlobalConstants::class => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Avoids having drama about typehints on the laravel preset.