### PR TITLE
[Fix]  assert ide is defined before resolving it

### DIFF
--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -82,7 +82,7 @@ final class Configuration
     /**
      * Configuration constructor.
      *
-     * @param array<string, string|array> $config
+     * @param array<string, string|array|null> $config
      */
     public function __construct(array $config)
     {
@@ -169,7 +169,7 @@ final class Configuration
     }
 
     /**
-     * @param array<string, string|array> $config
+     * @param array<string, string|array|null> $config
      */
     private function resolveConfig(array $config): void
     {
@@ -198,8 +198,12 @@ final class Configuration
         $this->remove = $config['remove'];
         $this->config = $config['config'];
 
-        if (array_key_exists('ide', $config)) {
-            $this->fileLinkFormatter = $this->resolveIde($config['ide']);
+        if (
+            array_key_exists('ide', $config)
+            && is_string($config['ide'])
+            && $config['ide'] !== ''
+        ) {
+            $this->fileLinkFormatter = $this->resolveIde((string) $config['ide']);
         }
     }
 
@@ -249,6 +253,7 @@ final class Configuration
             return true;
         };
     }
+
     private function resolveIde(string $ide): FileLinkFormatterContract
     {
         $links = [

--- a/tests/Domain/ConfigurationTest.php
+++ b/tests/Domain/ConfigurationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain;
+
+use NunoMaduro\PhpInsights\Domain\Configuration;
+use NunoMaduro\PhpInsights\Domain\Exceptions\InvalidConfiguration;
+use NunoMaduro\PhpInsights\Domain\LinkFormatter\FileLinkFormatter;
+use NunoMaduro\PhpInsights\Domain\LinkFormatter\NullFileLinkFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationTest extends TestCase
+{
+    public function testPassEmptyArrayReturnDefaultConfiguration(): void
+    {
+        $configuration = new Configuration([]);
+
+        self::assertEquals(getcwd(), $configuration->getDirectory());
+        self::assertEquals('default', $configuration->getPreset());
+        self::assertEquals([], $configuration->getAdd());
+        self::assertEquals([], $configuration->getExcludes());
+        self::assertEquals([], $configuration->getConfig());
+        self::assertEquals([], $configuration->getRemoves());
+    }
+
+    public function testWithNullIde(): void
+    {
+        $config = [
+            'ide' => null,
+        ];
+
+        $configuration = new Configuration($config);
+
+        self::assertInstanceOf(NullFileLinkFormatter::class, $configuration->getFileLinkFormatter());
+    }
+
+    public function testWithEmptyIde(): void
+    {
+        $config = [
+            'ide' => '',
+        ];
+
+        $configuration = new Configuration($config);
+
+        self::assertInstanceOf(NullFileLinkFormatter::class, $configuration->getFileLinkFormatter());
+    }
+
+    public function testWithSelectedIde(): void
+    {
+        $config = [
+            'ide' => 'sublime',
+        ];
+
+        $configuration = new Configuration($config);
+        self::assertInstanceOf(FileLinkFormatter::class, $configuration->getFileLinkFormatter());
+    }
+
+    public function testWithUnknowIde(): void
+    {
+        self::expectException(InvalidConfiguration::class);
+        self::expectExceptionMessage('Unknow IDE "notepad++"');
+
+        $config = [
+            'ide' => 'notepad++',
+        ];
+
+        new Configuration($config);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #318 

In default stub, we add `'ide' => null` to configure url handle. However, this null value wasn't catched. 

This is now fixed