### PR TITLE
Add php7.4 on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 php:
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 env:
   - COMPOSER_FLAGS="--prefer-lowest"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I just test phpinsights locally on php7.4, everything went well :clap: 

So I just add it to travis to keep things working

