### PR TITLE
Support slevomat coding standard 6

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -142,15 +142,16 @@
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments"/>
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
-        <exclude phpcbf-only="true" name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration"/>
-    </rule>-->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
 
     <!-- Code > Functions -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 env:
   - COMPOSER_FLAGS="--prefer-lowest"

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "composer/composer": "^1.7",
         "friendsofphp/php-cs-fixer": "^2.15",
         "league/container": "^3.2",
-        "object-calisthenics/phpcs-calisthenics-rules": "^3.5",
+        "object-calisthenics/phpcs-calisthenics-rules": "^3.7",
         "phploc/phploc": "^5.0",
         "psr/container": "^1.0",
         "sensiolabs/security-checker": "^6.0",
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "^6.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/console": "^4.2|^5.0",
         "symfony/finder": "^4.2|^5.0"
@@ -30,14 +30,13 @@
     "require-dev": {
         "illuminate/console": "^5.8",
         "illuminate/support": "^5.8",
-        "localheinz/phpstan-rules": "^0.10.0",
+        "ergebnis/phpstan-rules": "^0.14.0",
         "mockery/mockery": "^1.0",
-        "phpstan/phpstan-strict-rules": "^0.11",
+        "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^8.0",
-        "roave/no-floaters": "^1.1",
         "symfony/var-dumper": "^4.2|^5.0",
-        "symplify/easy-coding-standard": "^6.0",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.0"
+        "symplify/easy-coding-standard": "^7.1",
+        "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
     "suggest": {
         "ext-simplexml": "It is needed for the checkstyle formatter"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "ext-tokenizer": "*",
         "composer/composer": "^1.7",
         "friendsofphp/php-cs-fixer": "^2.15",
+        "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.7",
         "phploc/phploc": "^5.0",

--- a/config/container.php
+++ b/config/container.php
@@ -11,7 +11,7 @@ use NunoMaduro\PhpInsights\Application\Injectors\Repositories;
 use NunoMaduro\PhpInsights\Domain\Contracts\FileProcessor;
 use NunoMaduro\PhpInsights\Domain\Contracts\InsightLoader;
 
-return (static function () {
+return (static function (): Container {
     $injectors = [
         Configuration::class,
         Repositories::class,

--- a/config/routes/console.php
+++ b/config/routes/console.php
@@ -6,7 +6,7 @@ use NunoMaduro\PhpInsights\Application\Console\Commands\AnalyseCommand;
 use NunoMaduro\PhpInsights\Application\Console\Commands\InvokableCommand;
 use NunoMaduro\PhpInsights\Application\Console\Definitions\AnalyseDefinition;
 
-return (static function () {
+return (static function (): array {
     $container = require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'container.php';
 
     $analyseCommand = new InvokableCommand(

--- a/docs/insights/code.md
+++ b/docs/insights/code.md
@@ -466,6 +466,24 @@ This sniff reports invalid inline phpDocs with `@var`.
 
 **Insight Class**: `SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff`
 
+## Useless Function doc comment <Badge text="^1.12"/> <Badge text="Code\Comments" type="warn"/>
+
+This sniff disallows useless doc comments. If the native method declaration contains everything and the phpDoc does not add anything useful, it's reported as useless.
+
+Some typehints can be enforced to be specified with a contained type, with `traversableTypeHints`. See the [official explanation](https://github.com/slevomat/coding-standard#slevomatcodingstandardcommentinguselessfunctiondoccomment-)
+
+**Insight Class**: `SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff`
+
+<details>
+    <summary>Configuration</summary>
+
+```php
+SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff::class => [
+    'traversableTypeHints' => []
+]
+```
+</details>
+
 ## Disallow Array type hint syntax <Badge text="^1.0"/> <Badge text="Code\Comments" type="warn"/>
 
 This sniff disallows usage of array type hint syntax (eg. `int[]`, `bool[][]`) in phpDocs in favour of generic type hint syntax (eg. `array<int>`, `array<array<bool>>`).
@@ -491,11 +509,29 @@ This sniff enforces `null` type hint on last position in annotations.
 
 **Insight Class**: `SlevomatCodingStandard\Sniffs\TypeHints\NullTypeHintOnLastPositionSniff`
 
-## Type hint declaration <Badge text="^1.0"/> <Badge text="Code\Comments" type="warn"/>
+## Type hint declaration <Badge text=">=1.0 <1.12"/> <Badge text="Code\Comments" type="warn"/>
 
-See the [official explanation](https://github.com/slevomat/coding-standard/#slevomatcodingstandardtypehintstypehintdeclaration-)
+See the [official explanation](https://github.com/slevomat/coding-standard/tree/5.0.4#slevomatcodingstandardtypehintstypehintdeclaration-)
 
 **Insight Class**: `SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff`
+
+## Parameter Type hint <Badge text="^1.12"/> <Badge text="Code\Comments" type="warn"/>
+
+See the [official explanation](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsparametertypehint-)
+
+**Insight Class**: `SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff`
+
+## Property Type hint <Badge text="^1.12"/> <Badge text="Code\Comments" type="warn"/>
+
+See the [official explanation](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintspropertytypehint-)
+
+**Insight Class**: `SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff`
+
+## Return Type hint <Badge text="^1.12"/> <Badge text="Code\Comments" type="warn"/>
+
+See the [official explanation](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsreturntypehint-)
+
+**Insight Class**: `SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff`
 
 ## Useless constant type hint <Badge text="^1.0"/> <Badge text="Code\Comments" type="warn"/>
 

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -8,6 +8,7 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\NoSilencedErrorsSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 
 return [
 
@@ -84,5 +85,8 @@ return [
                 'src/Domain/LinkFormatter/NullFileLinkFormatter.php',
             ],
         ],
+        PropertyTypeHintSniff::class => [
+            'enableNativeTypeHint' => false,
+        ]
     ],
 ];

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -87,6 +87,6 @@ return [
         ],
         PropertyTypeHintSniff::class => [
             'enableNativeTypeHint' => false,
-        ]
+        ],
     ],
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,6 +29,17 @@ parameters:
         - '#Casting to string something that#'
         - '#Instanceof between Illuminate\\Contracts\\Foundation\\Application and#'
         - '#Call to function method_exists\(\) with Symfony\\Component\\Console\\Formatter\\OutputFormatterStyle and #'
+        - '#Error suppression via "@" should not be used.#'
+        -
+            message: '#Control structures using switch should not be used.#'
+            path: src/Domain/Analyser.php
+        -
+            message: '#does not exist on SimpleXMLElement|null.#'
+            path: src/Application/Console/Formatters/Checkstyle.php
+        -
+            message: '#generic class ReflectionClass#'
+            path: src/Domain/Reflection.php
+        - '#NunoMaduro\\PhpInsights\\Domain\\File::addFixableError#'
     autoload_files:
         - %rootDir%/../../squizlabs/php_codesniffer/autoload.php
     reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
-    - vendor/localheinz/phpstan-rules/rules.neon
+    - vendor/ergebnis/phpstan-rules/rules.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
 
 parameters:

--- a/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
+++ b/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
@@ -19,8 +19,10 @@ use NunoMaduro\PhpInsights\Domain\Reflection;
  */
 final class InsightsCommand extends Command
 {
+    /** @var string */
     protected $name = 'insights';
 
+    /** @var string */
     protected $description = 'Analyze the code quality';
 
     public function handle(): int

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -13,9 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
  */
 final class AnalyseDefinition
 {
-    /**
-     * @return InputDefinition
-     */
     public static function get(): InputDefinition
     {
         return new InputDefinition([

--- a/src/Application/Console/Style.php
+++ b/src/Application/Console/Style.php
@@ -57,9 +57,6 @@ final class Style extends SymfonyStyle
         return $this;
     }
 
-    /**
-     * @return \Symfony\Component\Console\Output\OutputInterface
-     */
     public function getOutput(): OutputInterface
     {
         return $this->output;

--- a/src/Application/Injectors/Configuration.php
+++ b/src/Application/Injectors/Configuration.php
@@ -23,7 +23,7 @@ final class Configuration
     public function __invoke(): array
     {
         return [
-            \NunoMaduro\PhpInsights\Domain\Configuration::class => static function () {
+            \NunoMaduro\PhpInsights\Domain\Configuration::class => static function (): \NunoMaduro\PhpInsights\Domain\Configuration {
                 $input = new ArgvInput();
                 // merge application default definition with analyse definition.
                 $definition = (new Application())->getDefinition();

--- a/src/Application/Injectors/FileProcessors.php
+++ b/src/Application/Injectors/FileProcessors.php
@@ -22,12 +22,12 @@ final class FileProcessors
     public function __invoke(): array
     {
         return [
-            SniffFileProcessor::class => static function () {
+            SniffFileProcessor::class => static function (): SniffFileProcessor {
                 return new SniffFileProcessor(
                     new FileFactory()
                 );
             },
-            FixerFileProcessor::class => static function () {
+            FixerFileProcessor::class => static function (): FixerFileProcessor {
                 return new FixerFileProcessor(
                     new Differ()
                 );

--- a/src/Application/Injectors/InsightLoaders.php
+++ b/src/Application/Injectors/InsightLoaders.php
@@ -20,10 +20,10 @@ final class InsightLoaders
     public function __invoke(): array
     {
         return [
-            SniffLoader::class => static function () {
+            SniffLoader::class => static function (): SniffLoader {
                 return new SniffLoader();
             },
-            FixerLoader::class => static function () {
+            FixerLoader::class => static function (): FixerLoader {
                 return new FixerLoader();
             },
         ];

--- a/src/Application/Injectors/Repositories.php
+++ b/src/Application/Injectors/Repositories.php
@@ -21,7 +21,7 @@ final class Repositories
     public function __invoke(): array
     {
         return [
-            FilesRepository::class => static function () {
+            FilesRepository::class => static function (): LocalFilesRepository {
                 $finder = Finder::create();
 
                 return new LocalFilesRepository($finder);

--- a/src/Domain/Collector.php
+++ b/src/Domain/Collector.php
@@ -222,11 +222,6 @@ final class Collector
         $this->dir = $dir;
     }
 
-    /**
-     * @param  string  $filename
-     *
-     * @return void
-     */
     public function addFile(string $filename): void
     {
         $filename = str_replace($this->dir . '/', '', $filename);
@@ -237,27 +232,16 @@ final class Collector
         $this->currentFilename = $filename;
     }
 
-    /**
-     * @param  int  $number
-     *
-     * @return void
-     */
     public function incrementCommentLines(int $number): void
     {
         $this->commentLines += $number;
     }
 
-    /**
-     * @return void
-     */
     public function incrementLogicalLines(): void
     {
         $this->logicalLines++;
     }
 
-    /**
-     * @return void
-     */
     public function currentClassReset(): void
     {
         if ($this->currentClassComplexity > 0) {
@@ -269,62 +253,39 @@ final class Collector
         $this->currentClassLines = 0;
     }
 
-    /**
-     * @return void
-     */
     public function currentClassIncrementComplexity(): void
     {
         $this->currentClassComplexity++;
     }
 
-    /**
-     * @return void
-     */
     public function currentClassIncrementLines(): void
     {
         $this->currentClassLines++;
     }
 
-    /**
-     * @return void
-     */
     public function currentMethodStart(): void
     {
         $this->currentMethodComplexity = 1;
         $this->currentMethodLines = 0;
     }
 
-    /**
-     * @return void
-     */
     public function currentMethodIncrementComplexity(): void
     {
         $this->currentMethodComplexity++;
         $this->totalMethodComplexity++;
     }
 
-    /**
-     * @return void
-     */
     public function currentMethodIncrementLines(): void
     {
         $this->currentMethodLines++;
     }
 
-    /**
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function currentMethodStop(string $name): void
     {
         $this->methodComplexity[] = $this->currentMethodComplexity;
         $this->methodLines[$this->currentFilename . ':' . $name] = $this->currentMethodLines;
     }
 
-    /**
-     * @return void
-     */
     public function incrementFunctionLines(): void
     {
         $this->functionLines++;
@@ -332,68 +293,37 @@ final class Collector
 
     /**
      * Increase the complexity of the analysis.
-     *
-     * @return void
      */
     public function incrementComplexity(): void
     {
         $this->complexity++;
     }
 
-    /**
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function addPossibleConstantAccesses(string $name): void
     {
         $this->possibleConstantAccesses[] = $name;
     }
 
-    /**
-     * @param  int  $line
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function addGlobalFunctions(int $line, string $name): void
     {
         $this->globalFunctions[$this->currentFilename . ':' . $line] = $name;
     }
 
-    /**
-     * @param int $line
-     * @param string $name
-     *
-     * @return void
-     */
     public function addGlobalVariableAccesses(int $line, string $name): void
     {
         $this->globalVariableAccesses[$this->currentFilename . ':' . $line] = $name;
     }
 
-    /**
-     * @param int $line
-     * @param string $name
-     *
-     * @return void
-     */
     public function addSuperGlobalVariableAccesses(int $line, string $name): void
     {
         $this->superGlobalVariableAccesses[$this->currentFilename . ':' . $line] = $name;
     }
 
-    /**
-     * @return void
-     */
     public function incrementNonStaticAttributeAccesses(): void
     {
         $this->nonStaticAttributeAccesses++;
     }
 
-    /**
-     * @return void
-     */
     public function incrementStaticAttributeAccesses(): void
     {
         $this->staticAttributeAccesses++;
@@ -401,8 +331,6 @@ final class Collector
 
     /**
      * Increment if calling non static method.
-     *
-     * @return void
      */
     public function incrementNonStaticMethodCalls(): void
     {
@@ -411,17 +339,12 @@ final class Collector
 
     /**
      * Increment if a calling a static method.
-     *
-     * @return void
      */
     public function incrementStaticMethodCalls(): void
     {
         $this->staticMethodCalls++;
     }
 
-    /**
-     * @param  string  $namespace
-     */
     public function addNamespace(string $namespace): void
     {
         $this->namespaces[] = $namespace;
@@ -430,39 +353,22 @@ final class Collector
 
     /**
      * Increment if class is a interface.
-     *
-     * @return void
      */
     public function incrementInterfaces(): void
     {
         $this->interfaces++;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return void
-     */
     public function addAbstractClass(string $name): void
     {
         $this->abstractClasses[] = $name;
     }
 
-    /**
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function addConcreteFinalClass(string $name): void
     {
         $this->concreteFinalClasses[] = $name;
     }
 
-    /**
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function addConcreteNonFinalClass(string $name): void
     {
         $this->concreteNonFinalClasses[] = $name;
@@ -470,8 +376,6 @@ final class Collector
 
     /**
      * Increment if method.
-     *
-     * @return void
      */
     public function incrementNonStaticMethods(): void
     {
@@ -480,8 +384,6 @@ final class Collector
 
     /**
      * Increment if static method.
-     *
-     * @return void
      */
     public function incrementStaticMethods(): void
     {
@@ -490,8 +392,6 @@ final class Collector
 
     /**
      * Increment if public method.
-     *
-     * @return void
      */
     public function incrementPublicMethods(): void
     {
@@ -500,8 +400,6 @@ final class Collector
 
     /**
      * Increment if protected method.
-     *
-     * @return void
      */
     public function incrementProtectedMethods(): void
     {
@@ -510,19 +408,12 @@ final class Collector
 
     /**
      * Increment if private method.
-     *
-     * @return void
      */
     public function incrementPrivateMethods(): void
     {
         $this->privateMethods++;
     }
 
-    /**
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function addNamedFunctions(string $name): void
     {
         if (! array_key_exists($this->currentFilename, $this->namedFunctions)) {
@@ -534,27 +425,17 @@ final class Collector
 
     /**
      * Increment if anonymous function.
-     *
-     * @return void
      */
     public function incrementAnonymousFunctions(): void
     {
         $this->anonymousFunctions++;
     }
 
-    /**
-     * @return void
-     */
     public function incrementClassConstants(): void
     {
         $this->classConstants++;
     }
 
-    /**
-     * @param  string  $name
-     *
-     * @return void
-     */
     public function addGlobalConstant(string $name): void
     {
         $this->globalConstants[$this->currentFilename] = $name;
@@ -569,17 +450,12 @@ final class Collector
 
     /**
      * Returns the analysed dir.
-     *
-     * @return string
      */
     public function getDir(): string
     {
         return $this->dir;
     }
 
-    /**
-     * @return int
-     */
     public function getLines(): int
     {
         return $this->getCommentLines()
@@ -588,9 +464,6 @@ final class Collector
             + $this->getNotInClassesOrFunctions();
     }
 
-    /**
-     * @return int
-     */
     public function getCommentLines(): int
     {
         return $this->commentLines;
@@ -628,9 +501,6 @@ final class Collector
         return $this->traits;
     }
 
-    /**
-     * @return int
-     */
     public function getClassLines(): int
     {
         return (int) $this->getSum($this->classLines);
@@ -644,73 +514,46 @@ final class Collector
         return $this->classLines;
     }
 
-    /**
-     * @return string
-     */
     public function getCurrentFilename(): string
     {
         return $this->currentFilename;
     }
 
-    /**
-     * @return int
-     */
     public function getCurrentClassComplexity(): int
     {
         return $this->currentClassComplexity;
     }
 
-    /**
-     * @return int
-     */
     public function getCurrentClassLines(): int
     {
         return $this->currentClassLines;
     }
 
-    /**
-     * @return int
-     */
     public function getCurrentMethodComplexity(): int
     {
         return $this->currentMethodComplexity;
     }
 
-    /**
-     * @return int
-     */
     public function getCurrentMethodLines(): int
     {
         return $this->currentMethodLines;
     }
 
-    /**
-     * @return int
-     */
     public function getLogicalLines(): int
     {
         return $this->logicalLines;
     }
 
-    /**
-     * @return int
-     */
     public function getMethodComplexity(): int
     {
         return $this->totalMethodComplexity;
     }
 
-    /**
-     * @return int
-     */
     public function getClassConstants(): int
     {
         return $this->classConstants;
     }
 
-    /**
-     * @return int
-     */
     public function getFunctionLines(): int
     {
         return $this->functionLines;
@@ -732,9 +575,6 @@ final class Collector
         return $this->globalFunctions;
     }
 
-    /**
-     * @return int
-     */
     public function getStaticAttributeAccesses(): int
     {
         return $this->staticAttributeAccesses;
@@ -742,8 +582,6 @@ final class Collector
 
     /**
      * Returns the complexity of the analysed data.
-     *
-     * @return int
      */
     public function getComplexity(): int
     {
@@ -766,25 +604,16 @@ final class Collector
         return array_merge($this->globalVariableAccesses, $this->superGlobalVariableAccesses);
     }
 
-    /**
-     * @return int
-     */
     public function getNonStaticMethodCalls(): int
     {
         return $this->nonStaticMethodCalls;
     }
 
-    /**
-     * @return int
-     */
     public function getNonStaticAttributeAccesses(): int
     {
         return $this->nonStaticAttributeAccesses;
     }
 
-    /**
-     * @return int
-     */
     public function getAnonymousFunctions(): int
     {
         return $this->anonymousFunctions;
@@ -798,25 +627,16 @@ final class Collector
         return $this->namedFunctions;
     }
 
-    /**
-     * @return int
-     */
     public function getPublicMethods(): int
     {
         return $this->publicMethods;
     }
 
-    /**
-     * @return int
-     */
     public function getStaticMethods(): int
     {
         return $this->staticMethods;
     }
 
-    /**
-     * @return int
-     */
     public function getNonStaticMethods(): int
     {
         return $this->nonStaticMethods;
@@ -846,33 +666,21 @@ final class Collector
         return $this->namespaces;
     }
 
-    /**
-     * @return int
-     */
     public function getProtectedMethods(): int
     {
         return $this->protectedMethods;
     }
 
-    /**
-     * @return int
-     */
     public function getPrivateMethods(): int
     {
         return $this->privateMethods;
     }
 
-    /**
-     * @return int
-     */
     public function getStaticMethodCalls(): int
     {
         return $this->staticMethodCalls;
     }
 
-    /**
-     * @return int
-     */
     public function getInterfaces(): int
     {
         return $this->interfaces;
@@ -894,9 +702,6 @@ final class Collector
         return $this->superGlobalVariableAccesses;
     }
 
-    /**
-     * @return int
-     */
     public function getNonCommentLines(): int
     {
         return $this->getLines() - $this->getCommentLines();
@@ -910,57 +715,36 @@ final class Collector
         return $this->getAverage($this->classLines);
     }
 
-    /**
-     * @return int
-     */
     public function getMaximumClassLength(): int
     {
         return (int) $this->getMaximum($this->classLines);
     }
 
-    /**
-     * @return int
-     */
     public function getAverageMethodLength(): int
     {
         return (int) $this->getAverage($this->methodLines);
     }
 
-    /**
-     * @return int
-     */
     public function getMaximumMethodLength(): int
     {
         return (int) $this->getMaximum($this->methodLines);
     }
 
-    /**
-     * @return int
-     */
     public function getAverageFunctionLength(): int
     {
         return (int) $this->divide($this->getFunctionLines(), $this->getFunctions());
     }
 
-    /**
-     * @return int
-     */
     public function getNotInClassesOrFunctions(): int
     {
         return $this->getLogicalLines() - $this->getClassLines() - $this->getFunctionLines();
     }
 
-    /**
-     * @return float
-     */
     public function getAverageComplexityPerLogicalLine(): float
     {
         return $this->divide($this->getLogicalLines(), $this->getComplexity());
     }
 
-    /**
-     * @return float
-     */
     public function getAverageComplexityPerClass(): float
     {
         return $this->getAverage($this->classComplexity);
@@ -974,49 +758,31 @@ final class Collector
         return $this->classComplexity;
     }
 
-    /**
-     * @return int
-     */
     public function getMaximumClassComplexity(): int
     {
         return (int) $this->getMaximum($this->getClassComplexity());
     }
 
-    /**
-     * @return float
-     */
     public function getAverageComplexityPerMethod(): float
     {
         return $this->getAverage($this->methodComplexity);
     }
 
-    /**
-     * @return float
-     */
     public function getMaximumMethodComplexity(): float
     {
         return $this->getMaximum($this->methodComplexity);
     }
 
-    /**
-     * @return int
-     */
     public function getGlobalAccesses(): int
     {
         return $this->getGlobalConstantAccesses() + count($this->globalVariableAccesses) + count($this->superGlobalVariableAccesses);
     }
 
-    /**
-     * @return int
-     */
     public function getGlobalConstantAccesses(): int
     {
         return count(\array_intersect($this->possibleConstantAccesses, $this->globalConstants));
     }
 
-    /**
-     * @return int
-     */
     public function getAttributeAccesses(): int
     {
         return $this->getNonStaticAttributeAccesses() + $this->getStaticAttributeAccesses();
@@ -1024,8 +790,6 @@ final class Collector
 
     /**
      * Get the amount of calls to methods analysed.
-     *
-     * @return int
      */
     public function getMethodCalls(): int
     {
@@ -1034,8 +798,6 @@ final class Collector
 
     /**
      * Get the amount of classes analysed.
-     *
-     * @return int
      */
     public function getClasses(): int
     {
@@ -1044,8 +806,6 @@ final class Collector
 
     /**
      * Get the amount of methods analysed.
-     *
-     * @return int
      */
     public function getMethods(): int
     {
@@ -1054,8 +814,6 @@ final class Collector
 
     /**
      * Get the amount of functions analysed.
-     *
-     * @return int
      */
     public function getFunctions(): int
     {
@@ -1064,8 +822,6 @@ final class Collector
 
     /**
      * Get the amount of constants analysed.
-     *
-     * @return int
      */
     public function getConstants(): int
     {
@@ -1116,12 +872,6 @@ final class Collector
         return (bool) count($array) ? max($array) : 0;
     }
 
-    /**
-     * @param  float  $x
-     * @param  float  $y
-     *
-     * @return float
-     */
     private function divide(float $x, float $y): float
     {
         return $y !== 0.0 ? $x / $y : 0;

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -209,7 +209,7 @@ final class Configuration
 
     private function validateAddedInsight(): \Closure
     {
-        return static function ($values) {
+        return static function ($values): bool {
             foreach ($values as $metric => $insights) {
                 if (! class_exists($metric) ||
                     ! in_array(Metric::class, class_implements($metric), true)
@@ -241,7 +241,7 @@ final class Configuration
 
     private function validateConfigInsights(): \Closure
     {
-        return static function ($values) {
+        return static function ($values): bool {
             foreach (array_keys($values) as $insight) {
                 if (! class_exists((string) $insight)) {
                     throw new InvalidConfiguration(sprintf(

--- a/src/Domain/Container.php
+++ b/src/Domain/Container.php
@@ -16,9 +16,6 @@ final class Container
      */
     private static $container;
 
-    /**
-     * @return \Psr\Container\ContainerInterface
-     */
     public static function make(): ContainerInterface
     {
         if (self::$container === null) {

--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -80,7 +80,9 @@ final class File extends BaseFile
     }
 
     /**
-     * {@inheritdoc}
+     * Disabling the errors functionality.
+     *
+     * @return array<string>
      */
     public function getErrors(): array
     {

--- a/src/Domain/Helper/Files.php
+++ b/src/Domain/Helper/Files.php
@@ -24,9 +24,13 @@ final class Files
         $finder = Finder::create();
         $finder
             ->in($basedir)
-            ->path(array_map(static function ($path) use ($basedir) {
+            ->path(array_map(static function (string $path) use ($basedir): string {
                 if (is_file($path)) {
-                    $path = realpath($path);
+                    $realPath = realpath($path);
+
+                    if ($realPath !== false) {
+                        $path = $realPath;
+                    }
                 }
                 return str_replace($basedir . DIRECTORY_SEPARATOR, '', $path);
             }, $list))

--- a/src/Domain/Insights/CyclomaticComplexityIsHigh.php
+++ b/src/Domain/Insights/CyclomaticComplexityIsHigh.php
@@ -37,7 +37,7 @@ final class CyclomaticComplexityIsHigh extends Insight implements HasDetails
         $complexityLimit = $this->getMaxComplexity();
         $classesComplexity = array_filter(
             $this->collector->getClassComplexity(),
-            static function ($complexity) use ($complexityLimit) {
+            static function ($complexity) use ($complexityLimit): bool {
                 return $complexity > $complexityLimit;
             }
         );

--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -63,9 +63,6 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails
         return self::$details;
     }
 
-    /**
-     * @return \SensioLabs\Security\Result
-     */
     private function getResult(): Result
     {
         if (self::$result === null) {

--- a/src/Domain/Insights/Insight.php
+++ b/src/Domain/Insights/Insight.php
@@ -47,12 +47,12 @@ abstract class Insight implements InsightContract
         }
     }
 
-    public function getInsightClass(): string
+    final public function getInsightClass(): string
     {
         return static::class;
     }
 
-    protected function shouldSkipFile(string $file): bool
+    final protected function shouldSkipFile(string $file): bool
     {
         $filepath = $file;
         if (mb_strpos($file, $this->collector->getDir()) === false) {
@@ -67,9 +67,9 @@ abstract class Insight implements InsightContract
      *
      * @return array<string, string|int|float|array>
      */
-    protected function filterFilesWithoutExcluded(array $files): array
+    final protected function filterFilesWithoutExcluded(array $files): array
     {
-        return array_filter($files, function ($file): bool {
+        return array_filter($files, function (string $file): bool {
             return $this->shouldSkipFile($file) === false;
         }, ARRAY_FILTER_USE_KEY);
     }

--- a/src/Domain/Insights/InsightCollection.php
+++ b/src/Domain/Insights/InsightCollection.php
@@ -35,9 +35,6 @@ final class InsightCollection
         $this->insightsPerMetric = $insightsPerMetric;
     }
 
-    /**
-     * @return \NunoMaduro\PhpInsights\Domain\Collector
-     */
     public function getCollector(): Collector
     {
         return $this->collector;

--- a/src/Domain/Insights/InsightFactory.php
+++ b/src/Domain/Insights/InsightFactory.php
@@ -87,9 +87,6 @@ final class InsightFactory
         throw new RuntimeException(sprintf('Insight `%s` is not instantiable.', $errorClass));
     }
 
-    /**
-     * @param \Symfony\Component\Console\Output\OutputInterface $consoleOutput
-     */
     private function runInsightCollector(OutputInterface $consoleOutput): void
     {
         if ($this->ran === true) {

--- a/src/Domain/Metrics/Architecture/Classes.php
+++ b/src/Domain/Metrics/Architecture/Classes.php
@@ -44,6 +44,6 @@ final class Classes implements HasValue, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return count($collector->getFiles()) > 0 ? ($collector->getClasses() / count($collector->getFiles())) * 100 : 0;
+        return count($collector->getFiles()) > 0 ? $collector->getClasses() / count($collector->getFiles()) * 100 : 0;
     }
 }

--- a/src/Domain/Metrics/Architecture/Globally.php
+++ b/src/Domain/Metrics/Architecture/Globally.php
@@ -13,6 +13,6 @@ final class Globally implements HasPercentage
     {
         $value = count($collector->getFiles()) - $collector->getClasses() - $collector->getInterfaces() - count($collector->getTraits());
 
-        return count($collector->getFiles()) > 0 ? ($value / count($collector->getFiles())) * 100 : 0;
+        return count($collector->getFiles()) > 0 ? $value / count($collector->getFiles()) * 100 : 0;
     }
 }

--- a/src/Domain/Metrics/Architecture/Interfaces.php
+++ b/src/Domain/Metrics/Architecture/Interfaces.php
@@ -19,7 +19,7 @@ final class Interfaces implements HasValue, HasPercentage, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return count($collector->getFiles()) > 0 ? ($collector->getInterfaces() / count($collector->getFiles())) * 100 : 0;
+        return count($collector->getFiles()) > 0 ? $collector->getInterfaces() / count($collector->getFiles()) * 100 : 0;
     }
 
     /**

--- a/src/Domain/Metrics/Architecture/Traits.php
+++ b/src/Domain/Metrics/Architecture/Traits.php
@@ -20,7 +20,7 @@ final class Traits implements HasValue, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return count($collector->getFiles()) > 0 ? (count($collector->getTraits()) / count($collector->getFiles())) * 100 : 0;
+        return count($collector->getFiles()) > 0 ? count($collector->getTraits()) / count($collector->getFiles()) * 100 : 0;
     }
 
     /**

--- a/src/Domain/Metrics/Code/Classes.php
+++ b/src/Domain/Metrics/Code/Classes.php
@@ -31,7 +31,7 @@ final class Classes implements HasValue, HasPercentage, HasAvg, HasMax, HasInsig
 
     public function getPercentage(Collector $collector): float
     {
-        return $collector->getLines() > 0 ? ($collector->getClassLines() / $collector->getLines()) * 100 : 0;
+        return $collector->getLines() > 0 ? $collector->getClassLines() / $collector->getLines() * 100 : 0;
     }
 
     public function getAvg(Collector $collector): string

--- a/src/Domain/Metrics/Code/Comments.php
+++ b/src/Domain/Metrics/Code/Comments.php
@@ -37,7 +37,7 @@ final class Comments implements HasValue, HasPercentage, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return $collector->getLines() > 0 ? ($collector->getCommentLines() / $collector->getLines()) * 100 : 0;
+        return $collector->getLines() > 0 ? $collector->getCommentLines() / $collector->getLines() * 100 : 0;
     }
 
     /**

--- a/src/Domain/Metrics/Code/Comments.php
+++ b/src/Domain/Metrics/Code/Comments.php
@@ -16,13 +16,16 @@ use PhpCsFixer\Fixer\ControlStructure\NoBreakCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\ForbiddenCommentsSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
+use SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessInheritDocCommentSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DisallowArrayTypeHintSyntaxSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\LongTypeHintsSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\NullTypeHintOnLastPositionSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\UselessConstantTypeHintSniff;
 
 final class Comments implements HasValue, HasPercentage, HasInsights
@@ -53,7 +56,10 @@ final class Comments implements HasValue, HasPercentage, HasInsights
             DisallowMixedTypeHintSniff::class,
             LongTypeHintsSniff::class,
             NullTypeHintOnLastPositionSniff::class,
-            TypeHintDeclarationSniff::class,
+            ParameterTypeHintSniff::class,
+            PropertyTypeHintSniff::class,
+            ReturnTypeHintSniff::class,
+            UselessFunctionDocCommentSniff::class,
             UselessConstantTypeHintSniff::class,
             UselessInheritDocCommentSniff::class,
             NoBreakCommentFixer::class,

--- a/src/Domain/Metrics/Code/Functions.php
+++ b/src/Domain/Metrics/Code/Functions.php
@@ -30,7 +30,7 @@ final class Functions implements HasValue, HasPercentage, HasAvg, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return $collector->getLines() > 0 ? ($collector->getFunctionLines() / $collector->getLines()) * 100 : 0;
+        return $collector->getLines() > 0 ? $collector->getFunctionLines() / $collector->getLines() * 100 : 0;
     }
 
     public function getAvg(Collector $collector): string

--- a/src/Domain/Metrics/Code/Globally.php
+++ b/src/Domain/Metrics/Code/Globally.php
@@ -20,7 +20,7 @@ final class Globally implements HasValue, HasPercentage, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return $collector->getLines() > 0 ? ($collector->getNotInClassesOrFunctions() / $collector->getLines()) * 100 : 0;
+        return $collector->getLines() > 0 ? $collector->getNotInClassesOrFunctions() / $collector->getLines() * 100 : 0;
     }
 
     /**

--- a/src/Domain/Results.php
+++ b/src/Domain/Results.php
@@ -55,7 +55,7 @@ final class Results
         $avg = $this->collector->getAverageComplexityPerMethod() - 1.0;
 
         return (float) number_format(
-            100.0 - max(min(($avg * 100.0) / 3.0, 100.0), 0.0),
+            100.0 - max(min($avg * 100.0 / 3.0, 100.0), 0.0),
             1,
             '.',
             ''
@@ -135,7 +135,7 @@ final class Results
             }
         }
 
-        $percentage = (bool) $issuesNotFound ? (($issuesNotFound * 100.0) / $total) : 100.0;
+        $percentage = (bool) $issuesNotFound ? $issuesNotFound * 100.0 / $total : 100.0;
 
         return (float) number_format($percentage, 1, '.', '');
     }

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -111,8 +111,8 @@ final class Runner
         ProgressBar::setFormatDefinition('phpinsight', $format);
         $progressBar->setFormat('phpinsight');
 
-        if ('\\' !== \DIRECTORY_SEPARATOR
-            || 'Hyper' === getenv('TERM_PROGRAM')) {
+        if (\DIRECTORY_SEPARATOR !== '\\'
+            || getenv('TERM_PROGRAM') === 'Hyper') {
             $progressBar->setEmptyBarCharacter($emptyBarCharacter);
             $progressBar->setProgressCharacter($progressCharacter);
             $progressBar->setBarCharacter($barCharacter);
@@ -123,16 +123,16 @@ final class Runner
 
     private function getProgressFormat(): string
     {
-        switch ($this->output->getVerbosity()) {
-            // OutputInterface::VERBOSITY_QUIET: display is disabled anyway
-            case OutputInterface::VERBOSITY_VERBOSE:
-                return 'verbose';
-            case OutputInterface::VERBOSITY_VERY_VERBOSE:
-                return 'very_verbose';
-            case OutputInterface::VERBOSITY_DEBUG:
-                return 'debug';
-            default:
-                return 'normal';
+        $verbosity = $this->output->getVerbosity();
+        if ($verbosity === OutputInterface::VERBOSITY_VERBOSE) {
+            return 'verbose';
         }
+        if ($verbosity === OutputInterface::VERBOSITY_VERY_VERBOSE) {
+            return 'very_verbose';
+        }
+        if ($verbosity === OutputInterface::VERBOSITY_DEBUG) {
+            return 'debug';
+        }
+        return 'normal';
     }
 }

--- a/stubs/laravel.php
+++ b/stubs/laravel.php
@@ -8,10 +8,13 @@ use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenNormalClasses;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenPrivateMethods;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenTraits;
 use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Classes;
+use SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\AlphabeticallySortedUsesSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff;
-use SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 
 return [
 
@@ -76,7 +79,10 @@ return [
         ForbiddenDefineFunctions::class,
         ForbiddenNormalClasses::class,
         ForbiddenTraits::class,
-        TypeHintDeclarationSniff::class,
+        ParameterTypeHintSniff::class,
+        PropertyTypeHintSniff::class,
+        ReturnTypeHintSniff::class,
+        UselessFunctionDocCommentSniff::class,
     ],
 
     'config' => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Call protected/private method of a class.
      *
-     * @param  string  $class Instantiated object that we will run method on
+     * @param  class-string  $class Instantiated object that we will run method on
      * @param  string  $methodName Method name to call
      * @param  array<int, mixed>  $parameters Array of parameters to pass into method
      *
@@ -31,7 +31,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @throws ReflectionException
      */
-    public function invokeStaticMethod(
+    public final function invokeStaticMethod(
         string $class,
         string $methodName,
         array $parameters
@@ -51,7 +51,7 @@ abstract class TestCase extends BaseTestCase
      * @param string $dir
      * @return InsightCollection
      */
-    public function runAnalyserOnPreset(
+    public final function runAnalyserOnPreset(
         string $preset,
         array $filePaths,
         string $dir = ''
@@ -71,7 +71,7 @@ abstract class TestCase extends BaseTestCase
      * @param string        $dir
      * @return InsightCollection
      */
-    public function runAnalyserOnConfig(
+    public final function runAnalyserOnConfig(
         array $config,
         array $filePaths,
         string $dir = ''
@@ -98,13 +98,13 @@ abstract class TestCase extends BaseTestCase
      * Prepares a supplied fixture for a supplied sniffer class with the
      * supplied properties.
      *
-     * @param string                              $sniffClassName
+     * @param class-string                        $sniffClassName
      * @param string                              $fixtureFile
      * @param array<string, string|array<string>> $properties
      * @return LocalFile
      * @throws ReflectionException
      */
-    public static function prepareFixtureWithSniff(
+    public static final function prepareFixtureWithSniff(
         string $sniffClassName,
         string $fixtureFile,
         array $properties = []
@@ -134,7 +134,12 @@ abstract class TestCase extends BaseTestCase
         return new LocalFile($fixtureFile, $ruleset, $config);
     }
 
-    public static function getFilePathFromClass(string $className) : string
+    /**
+     * @param class-string $className
+     * @return string
+     * @throws \ReflectionException
+     */
+    public static final function getFilePathFromClass(string $className) : string
     {
         $reflector = new ReflectionClass($className);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,7 +31,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @throws ReflectionException
      */
-    public final function invokeStaticMethod(
+    final public function invokeStaticMethod(
         string $class,
         string $methodName,
         array $parameters
@@ -51,7 +51,7 @@ abstract class TestCase extends BaseTestCase
      * @param string $dir
      * @return InsightCollection
      */
-    public final function runAnalyserOnPreset(
+    final public function runAnalyserOnPreset(
         string $preset,
         array $filePaths,
         string $dir = ''
@@ -71,7 +71,7 @@ abstract class TestCase extends BaseTestCase
      * @param string        $dir
      * @return InsightCollection
      */
-    public final function runAnalyserOnConfig(
+    final public function runAnalyserOnConfig(
         array $config,
         array $filePaths,
         string $dir = ''
@@ -104,7 +104,7 @@ abstract class TestCase extends BaseTestCase
      * @return LocalFile
      * @throws ReflectionException
      */
-    public static final function prepareFixtureWithSniff(
+    final public static function prepareFixtureWithSniff(
         string $sniffClassName,
         string $fixtureFile,
         array $properties = []
@@ -139,7 +139,7 @@ abstract class TestCase extends BaseTestCase
      * @return string
      * @throws \ReflectionException
      */
-    public static final function getFilePathFromClass(string $className) : string
+    final public static function getFilePathFromClass(string $className) : string
     {
         $reflector = new ReflectionClass($className);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #340 

I inititiated a support for slevomat/coding-standard 6.0. Many other dependencies needed to be updated as well.

localheinz/phpstan-rules is abandonned so I changed it to ergebnis/phpstan-rules (see [packagist](https://packagist.org/packages/localheinz/phpstan-rules))
roave/no-floaters does not support phpstan/phpstan:^0.12 yet so I had to drop it (https://github.com/Roave/no-floaters/pull/18)

New rules make phpstan and insights fail. I did not want to take the responsibility to change the code yet as I don't know if some rules have to be ignored and which (in phpstan.neon.dist and phpinsights.php).

Feel free to tell me what to do next, I will be happy to continue on this.

