### PR TITLE
docs: Fix version for using github formatter

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -28,7 +28,7 @@ As `phpinsights` returns an exit error code if security issues are found, you ca
 
 **Note** : For a project inspection, you **should** never use this option to keep your project safe.
 
-## Github Action <Badge text="^1.12"/>
+## Github Action <Badge text="^1.13"/>
 
 If you use Github Action, you can launch PHP Insights with `--format=github-action` option.
 With that, annotations with issues will be added in Pull request.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I noticed that the version for github formatter is wrong in documentation. v1.12 was released without this feature. 

Now the PR #344 is merged, we can assume it'll be in v1.13 :tada: 

<!--
- Replace this comment by a description of what your PR is solving.
-->
