### PR TITLE
Add support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "symfony/finder": "^4.2|^5.0"
     },
     "require-dev": {
-        "illuminate/console": "^7.0",
-        "illuminate/support": "^7.0",
+        "illuminate/console": "^5.8|^6.0|^7.0",
+        "illuminate/support": "^5.8|^6.0|^7.0",
         "ergebnis/phpstan-rules": "^0.14.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.7",
-        "phploc/phploc": "^5.0",
+        "phploc/phploc": "^5.0|^6.0",
         "psr/container": "^1.0",
         "sensiolabs/security-checker": "^6.0",
         "slevomat/coding-standard": "^6.0",
@@ -29,8 +29,8 @@
         "symfony/finder": "^4.2|^5.0"
     },
     "require-dev": {
-        "illuminate/console": "^5.8",
-        "illuminate/support": "^5.8",
+        "illuminate/console": "^5.8|^6.0|^7.0",
+        "illuminate/support": "^5.8|^6.0|^7.0",
         "ergebnis/phpstan-rules": "^0.14.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
@@ -47,7 +47,7 @@
             "Tests\\": "tests/"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "RC",
     "autoload": {
         "psr-4": {
             "NunoMaduro\\PhpInsights\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "symfony/finder": "^4.2|^5.0"
     },
     "require-dev": {
-        "illuminate/console": "^5.8|^6.0|^7.0",
-        "illuminate/support": "^5.8|^6.0|^7.0",
+        "illuminate/console": "^7.0",
+        "illuminate/support": "^7.0",
         "ergebnis/phpstan-rules": "^0.14.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "symfony/var-dumper": "^4.2|^5.0",
         "symplify/easy-coding-standard": "^7.1",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -28,6 +28,8 @@ Then, use the `insights` Artisan command:
 php artisan insights
 ```
 
+> Note for Laravel 7 users : phpinsights requires [PHP 7.3+](https://php.net/releases/)
+
 ## Within Lumen
 
 Because we cannot use Artisan's publish command within a Lumen project you must manually copy the config file into your project:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #368

This PR add support for Laravel 7.

`phploc/phploc` was updated to `^5.0|^6.0` as only version 6.0 supports `symfony/console` 6

I had to downgrade `minimum stablility` to `RC` because `composer/composer` has no stable version supporting `symfony/console` 6 but there is a `1.10.0-RC` version. See on [packagist](https://packagist.org/packages/composer/composer)

