### PR TITLE
Add WordPress adapter

### DIFF
--- a/src/Application/Adapters/WordPress/Preset.php
+++ b/src/Application/Adapters/WordPress/Preset.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\PhpInsights\Application\Adapters\Symfony;
+
+use NunoMaduro\PhpInsights\Application\Composer;
+use NunoMaduro\PhpInsights\Application\ConfigResolver;
+use NunoMaduro\PhpInsights\Application\DefaultPreset;
+use NunoMaduro\PhpInsights\Domain\Contracts\Preset as PresetContract;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
+
+/**
+ * @internal
+ */
+final class Preset implements PresetContract
+{
+    public static function getName(): string
+    {
+        return 'wordpress';
+    }
+
+    public static function get(Composer $composer): array
+    {
+        $config = [
+            'exclude' => [
+                'web/wp',
+                'web/.htaccess',
+                'web/app/mu-plugins/',
+                'web/app/upgrade',
+                'web/app/uploads/',
+                'web/app/plugins/',
+            ],
+            'config' => [
+                ForbiddenFunctionsSniff::class => [
+                    'forbiddenFunctions' => [
+                        'eval' => null,
+                        'error_log' => null,
+                        'print_r' => null,
+                    ],
+                ],
+            ],
+        ];
+
+        return ConfigResolver::mergeConfig(DefaultPreset::get($composer), $config);
+    }
+
+    public static function shouldBeApplied(Composer $composer): bool
+    {
+        $requirements = $composer->getRequirements();
+
+        foreach (array_keys($requirements) as $requirement) {
+            $requirement = (string) $requirement;
+
+            if (strpos($requirement, 'johnpbloch/wordpress') !== false
+                || strpos($requirement, 'roots/wordpress') !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Application/Adapters/WordPress/Preset.php
+++ b/src/Application/Adapters/WordPress/Preset.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace NunoMaduro\PhpInsights\Application\Adapters\Symfony;
+namespace NunoMaduro\PhpInsights\Application\Adapters\WordPress;
 
 use NunoMaduro\PhpInsights\Application\Composer;
 use NunoMaduro\PhpInsights\Application\ConfigResolver;

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -8,6 +8,7 @@ use NunoMaduro\PhpInsights\Application\Adapters\Drupal\Preset as DrupalPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Laravel\Preset as LaravelPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Magento2\Preset as Magento2Preset;
 use NunoMaduro\PhpInsights\Application\Adapters\Symfony\Preset as SymfonyPreset;
+use NunoMaduro\PhpInsights\Application\Adapters\WordPress\Preset as WordPressPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Yii\Preset as YiiPreset;
 use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Contracts\Preset;
@@ -32,6 +33,7 @@ final class ConfigResolver
         SymfonyPreset::class,
         YiiPreset::class,
         Magento2Preset::class,
+        WordPressPreset::class,
         DefaultPreset::class,
     ];
 

--- a/stubs/wordpress.php
+++ b/stubs/wordpress.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Preset
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default preset that will be used by PHP Insights
+    | to make your code reliable, simple, and clean. However, you can always
+    | adjust the `Metrics` and `Insights` below in this configuration file.
+    |
+    | Supported: "default", "laravel", "symfony", "magento2", "drupal", "wordpress"
+    |
+    */
+
+    'preset' => 'wordpress',
+    /*
+    |--------------------------------------------------------------------------
+    | IDE
+    |--------------------------------------------------------------------------
+    |
+    | This options allow to add hyperlinks in your terminal to quickly open
+    | files in your favorite IDE while browsing your PhpInsights report.
+    |
+    | Supported: "textmate", "macvim", "emacs", "sublime", "phpstorm",
+    | "atom", "vscode".
+    |
+    | If you have another IDE that is not in this list but which provide an
+    | url-handler, you could fill this config with a pattern like this:
+    |
+    | myide://open?url=file://%f&line=%l
+    |
+    */
+
+    'ide' => null,
+    /*
+    |--------------------------------------------------------------------------
+    | Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may adjust all the various `Insights` that will be used by PHP
+    | Insights. You can either add, remove or configure `Insights`. Keep in
+    | mind, that all added `Insights` must belong to a specific `Metric`.
+    |
+    */
+
+    'exclude' => [
+        //  'path/to/directory-or-file'
+    ],
+
+    'add' => [
+        //  ExampleMetric::class => [
+        //      ExampleInsight::class,
+        //  ]
+    ],
+
+    'remove' => [
+        //  ExampleInsight::class,
+    ],
+
+    'config' => [
+        //  ExampleInsight::class => [
+        //      'key' => 'value',
+        //  ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Requirements
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define a level you want to reach per `Insights` category.
+    | When a score is lower than the minimum level defined, then an error
+    | code will be returned. This is optional and individually defined.
+    |
+    */
+
+    'requirements' => [
+//        'min-quality' => 0,
+//        'min-complexity' => 0,
+//        'min-architecture' => 0,
+//        'min-style' => 0,
+//        'disable-security-check' => false,
+    ],
+
+];

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -87,6 +87,14 @@ final class ConfigResolverTest extends TestCase
         self::assertSame('drupal', $preset);
     }
 
+    public function testGuessWordPress(): void
+    {
+        $preset = ConfigResolver::guess(
+            Composer::fromPath($this->baseFixturePath . 'ComposerWordPress' . DIRECTORY_SEPARATOR . 'composer.json')
+        );
+        self::assertSame('wordpress', $preset);
+    }
+
     public function testResolvedConfigIsCorrectlyMerged(): void
     {
         $config = [

--- a/tests/Fixtures/ConfigResolver/ComposerWordPress/composer.json
+++ b/tests/Fixtures/ConfigResolver/ComposerWordPress/composer.json
@@ -1,0 +1,67 @@
+{
+  "name": "roots/bedrock",
+  "type": "project",
+  "license": "MIT",
+  "description": "WordPress boilerplate with modern development tools, easier configuration, and an improved folder structure",
+  "homepage": "https://roots.io/bedrock/",
+  "authors": [
+    {
+      "name": "Scott Walkinshaw",
+      "email": "scott.walkinshaw@gmail.com",
+      "homepage": "https://github.com/swalkinshaw"
+    },
+    {
+      "name": "Ben Word",
+      "email": "ben@benword.com",
+      "homepage": "https://github.com/retlehs"
+    }
+  ],
+  "keywords": [
+    "bedrock", "composer", "roots", "wordpress", "wp", "wp-config"
+  ],
+  "support": {
+    "issues": "https://github.com/roots/bedrock/issues",
+    "forum": "https://discourse.roots.io/category/bedrock"
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://wpackagist.org"
+    }
+  ],
+  "require": {
+    "php": ">=7.1",
+    "composer/installers": "^1.8",
+    "vlucas/phpdotenv": "^4.1.0",
+    "oscarotero/env": "^1.2.0",
+    "roots/wordpress": "5.3.2",
+    "roots/wp-config": "1.0.0",
+    "roots/wp-password-bcrypt": "1.0.0"
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "^3.5.4",
+    "roave/security-advisories": "dev-master"
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "extra": {
+    "installer-paths": {
+      "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+      "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
+      "web/app/themes/{$name}/": ["type:wordpress-theme"]
+    },
+    "wordpress-install-dir": "web/wp"
+  },
+  "scripts": {
+    "post-root-package-install": [
+      "php -r \"copy('.env.example', '.env');\""
+    ],
+    "test": [
+      "phpcs"
+    ]
+  }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #35 

This is a feature for WordPress adapter. There is a small caveat - it currently works on [Bedrock](https://roots.io/bedrock/) version of WordPress (and `johnpbloch/wordpress` package). That is I haven't tested this on my plugin for instance, I'll do this later.

![c](https://user-images.githubusercontent.com/8638515/76544652-b0a2a380-6488-11ea-9fd8-c63005cbc1d4.png)

I only added config resolver test, not sure if I need to add anything else 🤷🏼‍♂️

