### PR TITLE
[Improvment] Performances

### DIFF
--- a/src/Domain/ComposerLoader.php
+++ b/src/Domain/ComposerLoader.php
@@ -13,9 +13,24 @@ use Composer\IO\NullIO;
  */
 final class ComposerLoader
 {
+    /**
+     * @var \NunoMaduro\PhpInsights\Domain\Collector
+     */
+    private static $currentCollector;
+    /**
+     * @var Composer|null
+     */
+    private static $composer;
+
     public static function getInstance(Collector $collector): Composer
     {
-        $io = new NullIO();
-        return Factory::create($io, ComposerFinder::getPath($collector));
+        if (null === self::$composer || $collector !== self::$currentCollector) {
+            self::$currentCollector = $collector;
+
+            $io = new NullIO();
+            self::$composer = Factory::create($io, ComposerFinder::getPath($collector));
+        }
+
+        return self::$composer;
     }
 }

--- a/src/Domain/Contracts/Repositories/FilesRepository.php
+++ b/src/Domain/Contracts/Repositories/FilesRepository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Contracts\Repositories;
 
-use Traversable;
-
 /**
  * @internal
  */
@@ -21,9 +19,9 @@ interface FilesRepository
     /**
      * Get the files.
      *
-     * @return Traversable<\Symfony\Component\Finder\SplFileInfo>
+     * @return array<\Symfony\Component\Finder\SplFileInfo>
      */
-    public function getFiles(): Traversable;
+    public function getFiles(): array;
 
     /**
      * Sets the current files directories.

--- a/src/Domain/FileProcessors/FixerFileProcessor.php
+++ b/src/Domain/FileProcessors/FixerFileProcessor.php
@@ -60,6 +60,7 @@ final class FixerFileProcessor implements FileProcessor
 
         try {
             $tokens = @Tokens::fromCode($oldContent);
+            $originalTokens = clone $tokens;
             /** @var FixerDecorator $fixer */
             foreach ($this->fixers as $fixer) {
                 $fixer->fix($splFileInfo, $tokens);
@@ -73,7 +74,7 @@ final class FixerFileProcessor implements FileProcessor
                 );
                 // Tokens has changed, so we need to clear cache
                 Tokens::clearCache();
-                $tokens = @Tokens::fromCode($oldContent);
+                $tokens = clone $originalTokens;
             }
         } catch (\Throwable $e) {
             // @ignoreException

--- a/src/Domain/Insights/Composer/ComposerMustContainName.php
+++ b/src/Domain/Insights/Composer/ComposerMustContainName.php
@@ -18,19 +18,38 @@ final class ComposerMustContainName extends Insight
         'symfony/symfony',
     ];
 
+    /**
+     * @var bool
+     */
+    private $analyzed = false;
+    /**
+     * @var bool
+     */
+    private $hasError = false;
+
     public function hasIssue(): bool
     {
-        try {
-            $contents = json_decode(ComposerFinder::contents($this->collector), true);
-        } catch (ComposerNotFound $e) {
-            return true;
+        if (! $this->analyzed) {
+            $this->check();
         }
 
-        return array_key_exists('name', $contents) && array_key_exists($contents['name'], array_flip($this->defaults));
+        return $this->hasError;
     }
 
     public function getTitle(): string
     {
         return 'The name property in the `composer.json` contains the default value';
+    }
+
+    private function check(): void
+    {
+        try {
+            $contents = json_decode(ComposerFinder::contents($this->collector), true);
+            $this->hasError = array_key_exists('name', $contents) && array_key_exists($contents['name'], array_flip($this->defaults));
+        } catch (ComposerNotFound $e) {
+            $this->hasError = true;
+        }
+
+        $this->analyzed = true;
     }
 }

--- a/src/Domain/Insights/Composer/ComposerMustExist.php
+++ b/src/Domain/Insights/Composer/ComposerMustExist.php
@@ -10,19 +10,36 @@ use NunoMaduro\PhpInsights\Domain\Insights\Insight;
 
 final class ComposerMustExist extends Insight
 {
+    /**
+     * @var bool
+     */
+    private $analyzed = false;
+    /**
+     * @var bool
+     */
+    private $hasError = false;
+
     public function hasIssue(): bool
     {
-        try {
-            ComposerFinder::contents($this->collector);
-        } catch (ComposerNotFound $e) {
-            return true;
+        if (! $this->analyzed) {
+            $this->check();
         }
 
-        return false;
+        return $this->hasError;
     }
 
     public function getTitle(): string
     {
         return 'The `composer.json` file was not found';
+    }
+
+    private function check(): void
+    {
+        try {
+            ComposerFinder::contents($this->collector);
+        } catch (ComposerNotFound $e) {
+            $this->hasError = true;
+        }
+        $this->analyzed = true;
     }
 }

--- a/src/Domain/Insights/InsightCollection.php
+++ b/src/Domain/Insights/InsightCollection.php
@@ -24,6 +24,11 @@ final class InsightCollection
     private $collector;
 
     /**
+     * @var Results
+     */
+    private $results;
+
+    /**
      * Creates a new instance of the Insight Collection.
      *
      * @param  \NunoMaduro\PhpInsights\Domain\Collector  $collector
@@ -77,21 +82,24 @@ final class InsightCollection
      */
     public function results(): Results
     {
-        $perCategory = [];
+        if (null === $this->results) {
+            $perCategory = [];
 
-        foreach ($this->insightsPerMetric as $metric => $insights) {
-            $category = explode('\\', $metric);
-            $category = $category[count($category) - 2];
+            foreach ($this->insightsPerMetric as $metric => $insights) {
+                $category = explode('\\', $metric);
+                $category = $category[count($category) - 2];
 
-            if (! array_key_exists($category, $perCategory)) {
-                $perCategory[$category] = [];
+                if (! array_key_exists($category, $perCategory)) {
+                    $perCategory[$category] = [];
+                }
+
+                $perCategory[$category] = array_merge(
+                    $perCategory[$category], $insights
+                );
             }
-
-            $perCategory[$category] = array_merge(
-                $perCategory[$category], $insights
-            );
+            $this->results = new Results($this->collector, $perCategory);
         }
 
-        return new Results($this->collector, $perCategory);
+        return $this->results;
     }
 }

--- a/src/Domain/Insights/InsightCollection.php
+++ b/src/Domain/Insights/InsightCollection.php
@@ -82,23 +82,24 @@ final class InsightCollection
      */
     public function results(): Results
     {
-        if (null === $this->results) {
-            $perCategory = [];
-
-            foreach ($this->insightsPerMetric as $metric => $insights) {
-                $category = explode('\\', $metric);
-                $category = $category[count($category) - 2];
-
-                if (! array_key_exists($category, $perCategory)) {
-                    $perCategory[$category] = [];
-                }
-
-                $perCategory[$category] = array_merge(
-                    $perCategory[$category], $insights
-                );
-            }
-            $this->results = new Results($this->collector, $perCategory);
+        if (null !== $this->results) {
+            return $this->results;
         }
+
+        $perCategory = [];
+        foreach ($this->insightsPerMetric as $metric => $insights) {
+            $category = explode('\\', $metric);
+            $category = $category[count($category) - 2];
+
+            if (! array_key_exists($category, $perCategory)) {
+                $perCategory[$category] = [];
+            }
+
+            $perCategory[$category] = array_merge(
+                $perCategory[$category], $insights
+            );
+        }
+        $this->results = new Results($this->collector, $perCategory);
 
         return $this->results;
     }

--- a/src/Domain/Insights/InsightCollectionFactory.php
+++ b/src/Domain/Insights/InsightCollectionFactory.php
@@ -64,7 +64,7 @@ final class InsightCollectionFactory
         try {
             $files = array_map(static function (\SplFileInfo $file) {
                 return $file->getRealPath();
-            }, iterator_to_array($this->filesRepository->within($dir, $this->config->getExcludes())->getFiles()));
+            }, $this->filesRepository->within($dir, $this->config->getExcludes())->getFiles());
         } catch (\InvalidArgumentException $exception) {
             throw new DirectoryNotFound($exception->getMessage(), 0, $exception);
         }

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -58,7 +58,6 @@ final class Runner
     {
         // Get the files.
         $files = $this->filesRepository->getFiles();
-        $files = iterator_to_array($files);
 
         // No files found
         if (count($files) === 0) {

--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -6,7 +6,6 @@ namespace NunoMaduro\PhpInsights\Infrastructure\Repositories;
 
 use NunoMaduro\PhpInsights\Domain\Contracts\Repositories\FilesRepository;
 use Symfony\Component\Finder\Finder;
-use Traversable;
 
 /**
  * @internal
@@ -17,6 +16,11 @@ final class LocalFilesRepository implements FilesRepository
      * @var \Symfony\Component\Finder\Finder
      */
     private $finder;
+
+    /**
+     * @var array<\Symfony\Component\Finder\SplFileInfo>
+     */
+    private $files;
 
     public function __construct(Finder $finder)
     {
@@ -34,9 +38,13 @@ final class LocalFilesRepository implements FilesRepository
         return (string) getcwd();
     }
 
-    public function getFiles(): Traversable
+    public function getFiles(): array
     {
-        return $this->finder->getIterator();
+        if (null === $this->files) {
+            $this->files = iterator_to_array($this->finder->getIterator(), true);
+        }
+
+        return $this->files;
     }
 
     public function within(string $path, array $exclude = []): FilesRepository
@@ -56,6 +64,8 @@ final class LocalFilesRepository implements FilesRepository
                 $this->finder->notName($value);
             }
         }
+
+        $this->files = iterator_to_array($this->finder->getIterator(), true);
 
         return $this;
     }

--- a/tests/Fakes/FakeFileRepository.php
+++ b/tests/Fakes/FakeFileRepository.php
@@ -33,9 +33,9 @@ final class FakeFileRepository implements FilesRepository
         return (string) getcwd();
     }
 
-    public function getFiles(): Traversable
+    public function getFiles(): array
     {
-        return new ArrayIterator($this->files);
+        return $this->files;
     }
 
     public function within(string $dir, array $exclude): FilesRepository

--- a/tests/Infrastructure/Repositories/LocalFilesRepositoryTest.php
+++ b/tests/Infrastructure/Repositories/LocalFilesRepositoryTest.php
@@ -64,7 +64,7 @@ final class LocalFilesRepositoryTest extends TestCase
         $repository = new LocalFilesRepository($finder);
         $repository->within(__DIR__.'/Fixtures/FolderWithBladeFile');
 
-        $files = iterator_to_array($repository->getFiles());
+        $files = $repository->getFiles();
 
         self::assertEmpty($files);
     }
@@ -75,11 +75,11 @@ final class LocalFilesRepositoryTest extends TestCase
 
         $repository = new LocalFilesRepository($finder);
         $repository->within(__DIR__ . '/Fixtures/FileToInspect.php');
-        $files = iterator_to_array($repository->getFiles(), false);
+        $files = $repository->getFiles();
 
         self::assertCount(1, $files);
-        self::assertInstanceOf(SplFileInfo::class, $files[0]);
-        $path = $files[0]->getRealPath();
+        self::assertInstanceOf(SplFileInfo::class, $files[__DIR__ . '/Fixtures/FileToInspect.php']);
+        $path = $files[__DIR__ . '/Fixtures/FileToInspect.php']->getRealPath();
 
         if ($path === false) {
             self::fail('Path cannot be false.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Hey :wave: 

Past days, I continued to play with blackfire to see how we can speed up PHPInsights.

I found some ways:  
Using Symfony Finder cost a lot, particulary when we had to call an iterator_to_array on it.

We call severall times hasIssue on Insights during process, and some of them had huge task to calculate issues. 

Same for Results from InsightsCollection, called twice with lot of foreach inside.  

You can check the comparison between master branch and mine:  https://blackfire.io/profiles/compare/4c42280b-0b72-435d-956e-d54afb4b82fe/graph

I gain 26% of time speed :raised_hands: 