### PR TITLE
feat(ruleset): Only instantiate ruleset once

### DIFF
--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -25,26 +25,18 @@ final class File extends BaseFile
      */
     private $fileInfo;
 
-    /**
-     * File constructor.
-     *
-     * @param string $path
-     * @param string $content
-     */
-    public function __construct(string $path, string $content)
+    public function __construct(string $path,
+                                string $content,
+                                Config $config,
+                                Ruleset $ruleset)
     {
         $this->content = $content;
 
         $this->eolChar = Common::detectLineEndings($content);
 
-        $config = new Config([], false);
-        $config->__set('tabWidth', 4);
-        $config->__set('annotations', false);
-        $config->__set('encoding', 'UTF-8');
-
         parent::__construct(
             $path,
-            new Ruleset($config),
+            $ruleset,
             $config
         );
     }

--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -25,11 +25,12 @@ final class File extends BaseFile
      */
     private $fileInfo;
 
-    public function __construct(string $path,
-                                string $content,
-                                Config $config,
-                                Ruleset $ruleset)
-    {
+    public function __construct(
+        string $path,
+        string $content,
+        Config $config,
+        Ruleset $ruleset
+    ) {
         $this->content = $content;
 
         $this->eolChar = Common::detectLineEndings($content);

--- a/src/Domain/FileFactory.php
+++ b/src/Domain/FileFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain;
 
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
 use RuntimeException;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -12,6 +14,23 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 final class FileFactory
 {
+    /** @var \PHP_CodeSniffer\Ruleset */
+    private $ruleset;
+
+    /** @var \PHP_CodeSniffer\Config */
+    private $config;
+
+    public function __construct()
+    {
+        $config = new Config([], false);
+        $config->__set('tabWidth', 4);
+        $config->__set('annotations', false);
+        $config->__set('encoding', 'UTF-8');
+
+        $this->config = $config;
+        $this->ruleset = new Ruleset($config);
+    }
+
     public function createFromFileInfo(SplFileInfo $smartFileInfo): File
     {
         $path = $smartFileInfo->getRealPath();
@@ -24,7 +43,9 @@ final class FileFactory
 
         return new File(
             $path,
-            $smartFileInfo->getContents()
+            $smartFileInfo->getContents(),
+            $this->config,
+            $this->ruleset
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no

Looking at a [blackfire analysis](https://blackfire.io/profiles/0cdf3b41-a85d-4b3e-95c1-ce0c2e281df8/graph), I saw that we spent roughly 10% constructing PHPCS ruleset for each file
![image](https://user-images.githubusercontent.com/5870441/78336830-516c1680-7590-11ea-8efb-fb8e7b567747.png)

However a ruleset is not bound to a file, so this change does so we only create one ruleset and use that for each file, hence saving a lot of time.

A comparison of can be found [here](https://blackfire.io/profiles/compare/ecc5008d-6cc2-4b8d-bb23-5e59608e842e/graph).


Thanks @Jibbarth for reminding me about blackfire ❤️ 
