### PR TITLE
fix(composer): Check that lock file exist

### DIFF
--- a/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
+++ b/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
@@ -16,8 +16,13 @@ final class ComposerLockMustBeFresh extends Insight implements HasDetails
     {
         try {
             $composer = ComposerLoader::getInstance($this->collector);
+            $locker = $composer->getLocker();
 
-            return ! $composer->getLocker()->isFresh();
+            if (! $locker->isLocked()) {
+                return true;
+            }
+
+            return ! $locker->isFresh();
         } catch (ComposerNotFound $exception) {
             return true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

If you run php insights on a project that does not contain a `composer.lock` file it will fail, this add's a check for the lock file also. 
