### PR TITLE
Fix #401

### DIFF
--- a/src/Domain/FileFactory.php
+++ b/src/Domain/FileFactory.php
@@ -21,9 +21,13 @@ final class FileFactory
     public function __construct()
     {
         $config = new Config([], false);
+        // disable loading custom ruleset
+        $config->restoreDefaults();
         $config->__set('tabWidth', 4);
         $config->__set('annotations', false);
         $config->__set('encoding', 'UTF-8');
+        // Include only 1 sniff, they are register later
+        $config->__set('sniffs', ['Generic.Files.LineEndings']);
 
         $this->config = $config;
         $this->ruleset = new Ruleset($this->config);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| Fixed tickets | #401 

CF https://github.com/nunomaduro/phpinsights/issues/401#issuecomment-625768980 the Config for PHPCS load .phpcs.xml from project.

That is useless for us, because we register sniff based on phpinsights.php configuration later, by file.

So I restore the standard config to remove this .phpcs.xml use, and restrict config to only 1 diff (without 1, the ruleset creation throw an error).