### PR TITLE
Fix display detail message without file

### DIFF
--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -586,8 +586,10 @@ final class Console implements Formatter
             $formattedLink = $this->fileLinkFormatter->format($file, $detail->getLine());
         }
 
-        $color = $this->getCategoryColor($category);
-        $detailString = sprintf('<fg=%s>%s</>', $color, $detailString);
+        if ($detailString !== '') {
+            $color = $this->getCategoryColor($category);
+            $detailString = sprintf('<fg=%s>%s</>', $color, $detailString);
+        }
 
         if ($this->supportHyperLinks &&
             $formattedLink !== '' &&


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Just noticed when an Insight has issue without file associated in Detail, there is a weird render:

![image](https://user-images.githubusercontent.com/3168281/81473613-ea312a00-91ff-11ea-8bcc-231e0f7244e0.png)

This fix that:

![image](https://user-images.githubusercontent.com/3168281/81473624-05039e80-9200-11ea-9e92-fda1ac6511b0.png)
