### PR TITLE
[Improvement] Reduce set_error_handler call

### DIFF
--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -12,7 +12,6 @@ use NunoMaduro\PhpInsights\Domain\File as InsightFile;
 use NunoMaduro\PhpInsights\Domain\Helper\Files;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use RuntimeException;
 
 /**
  * Decorates original php-cs sniffs with additional behavior.
@@ -62,10 +61,6 @@ final class SniffDecorator implements Sniff, Insight, HasDetails, Fixable
      */
     public function process(File $file, $stackPtr)
     {
-        set_error_handler(static function (): bool {
-            throw new RuntimeException();
-        }, E_NOTICE);
-
         if ($file instanceof InsightFile && $this->skipFilesFromIgnoreFiles($file)) {
             return;
         }

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -89,6 +89,10 @@ final class Runner
             $progressBar->advance();
         }
 
+        set_error_handler(static function (int $errno, string $errstr): bool {
+            throw new \RuntimeException($errstr, $errno);
+        }, E_NOTICE);
+
         /** @var SplFileInfo $file */
         foreach ($files as $file) {
             // Output file name if verbose


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I noticed analysing with blackfire that set_error_handler is called multiple times.

By moving it from sniffDecorator to Runner, we gain 61% of memory usage. 

See the [blackfire compare profile](https://blackfire.io/profiles/compare/06a83806-75e0-4ed5-9247-9a4ef8cb7aab/graph)

@50bhan, as you added it in #358, could you please check if everything is okay for you with that change ? 🙏
