### PR TITLE
[UX] launch securitycheck as global

### DIFF
--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
+use NunoMaduro\PhpInsights\Domain\Contracts\GlobalInsight;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Exceptions\InternetConnectionNotFound;
@@ -11,7 +12,7 @@ use SensioLabs\Security\Result;
 use SensioLabs\Security\SecurityChecker;
 use Throwable;
 
-final class ForbiddenSecurityIssues extends Insight implements HasDetails
+final class ForbiddenSecurityIssues extends Insight implements HasDetails, GlobalInsight
 {
     private static ?Result $result = null;
 
@@ -28,6 +29,11 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails
     public function getTitle(): string
     {
         return 'Security issues found on dependencies';
+    }
+
+    public function process(): void
+    {
+        $this->getResult();
     }
 
     public function getDetails(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

User experiment improve. 

I noticed the ForbiddenSecurity check, that call an external webservice, may brievly stop display resume. 

By defining it as GlobalInsight, it'll be launched during analyse, so there is no more stop after. 

Demo with a slow 2G connection: 
![security-check-global](https://user-images.githubusercontent.com/3168281/81493811-d8a15e00-92a3-11ea-9a8e-db631192c727.gif)
