### PR TITLE
Small typo fix

### DIFF
--- a/docs/insights/style.md
+++ b/docs/insights/style.md
@@ -776,7 +776,7 @@ This sniff orders `use` statements (import of classes).
 
 ```php
 \PhpCsFixer\Fixer\Import\OrderedImportsFixer::class => [
-    'import_order' => ['class', 'const', 'function'],
+    'imports_order' => ['class', 'const', 'function'],
     'sort_algorithm' => 'alpha', // possible values ['alpha', 'length', 'none']
 ]
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

[ordered_imports] Invalid configuration: The option "import_order" does not exist. Defined options are: "imports_order", "sort_algorithm".
