### PR TITLE
Fix ide link with colors

### DIFF
--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -586,20 +586,20 @@ final class Console implements Formatter
             $formattedLink = $this->fileLinkFormatter->format($file, $detail->getLine());
         }
 
-        if ($detailString !== '') {
-            $color = $this->getCategoryColor($category);
-            $detailString = sprintf('<fg=%s>%s</>', $color, $detailString);
-        }
-
         if ($this->supportHyperLinks &&
             $formattedLink !== '' &&
             $detailString !== ''
         ) {
-            $detailString = sprintf(
-                '<href=%s>%s</>',
+            return sprintf(
+                '<href=%s;fg=%s>%s</>',
                 $formattedLink,
+                $this->getCategoryColor($category),
                 $detailString
             );
+        }
+
+        if ($detailString !== '') {
+            $detailString = sprintf('<fg=%s>%s</>', $this->getCategoryColor($category), $detailString);
         }
 
         return $detailString;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I noticed that IDE link doesn't longer work since we add color on files.

This PR fix it :

![before/after](https://user-images.githubusercontent.com/3168281/85222837-884b0f00-b3be-11ea-86e4-c877434cd268.png)
 
