### PR TITLE
WIP: Do not generate insights for files ignored by VCS

### DIFF
--- a/src/Application/Injectors/Repositories.php
+++ b/src/Application/Injectors/Repositories.php
@@ -22,7 +22,7 @@ final class Repositories
     {
         return [
             FilesRepository::class => static function (): LocalFilesRepository {
-                $finder = Finder::create();
+                $finder = Finder::create()->ignoreVCSIgnored(true);
 
                 return new LocalFilesRepository($finder);
             },

--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -91,7 +91,7 @@ final class LocalFilesRepository implements FilesRepository
             return [];
         }
 
-        $directories = array_column($directories, 'full_path');
+        $directories = array_unique(array_column($directories, 'full_path'));
 
         $finder = (clone $this->finder)
             ->files()
@@ -122,18 +122,20 @@ final class LocalFilesRepository implements FilesRepository
             return [];
         }
 
-        $dirname = array_column($paths, 'dirname');
-        $basename = array_column($paths, 'basename');
-        $full_path = array_column($paths, 'full_path');
+        $directories = array_unique(array_column($paths, 'dirname'));
+        $basenames = array_unique(array_column($paths, 'basename'));
+        $full_paths = array_column($paths, 'full_path');
+
+        $fullPathIsMatched = fn (SplFileInfo $file): bool => in_array(
+            $file->getPathname(),
+            $full_paths,
+            true
+        );
 
         $finder = (clone $this->finder)
-            ->in($dirname)
-            ->name($basename)
-            ->filter(fn (SplFileInfo $file): bool => in_array(
-                $file->getPathname(),
-                $full_path,
-                true
-            ));
+            ->in($directories)
+            ->name($basenames)
+            ->filter($fullPathIsMatched);
 
         return $this->getFilesList($finder);
     }

--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -43,7 +43,7 @@ final class LocalFilesRepository implements FilesRepository
     }
 
     /**
-     * @return array<string, \Symfony\Component\Finder\SplFileInfo>
+     * @return array<\Symfony\Component\Finder\SplFileInfo>
      */
     public function getFiles(): array
     {
@@ -80,10 +80,10 @@ final class LocalFilesRepository implements FilesRepository
     }
 
     /**
-     * @param array<string> $directories
+     * @param array<array> $directories
      * @param array<string> $exclude
      *
-     * @return array<string, \Symfony\Component\Finder\SplFileInfo>
+     * @return array<\Symfony\Component\Finder\SplFileInfo>
      */
     private function filesWithinDirectories(array $directories, array $exclude = []): array
     {
@@ -112,9 +112,9 @@ final class LocalFilesRepository implements FilesRepository
     }
 
     /**
-     * @param array<string> $paths
+     * @param array<array> $paths
      *
-     * @return array<string, \Symfony\Component\Finder\SplFileInfo>
+     * @return array<\Symfony\Component\Finder\SplFileInfo>
      */
     private function filesAtPaths(array $paths): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Per #248 

I wanted to add the VCS ignore as a configurable option and it looked pretty difficult to do with the current implementation, so I did a little refactor and moved the VCS ignore setting on the Finder into the class responsible for instantiating the LocalFileRepository. 

This is marked as WIP because I still need to determine the right approach to make it configurable, but I've run out of time today. I'll come back to this ASAP but if anyone else wants to take over it, feel free. I think it needs to be configurable to maintain backwards compatibility.

Also if this refactor doesn't meet expectations -- i.e: isn't the approach that is preferred -- I won't be offended by a rejection or requested changes :-) 