### PR TITLE
feat: Allow hiding summary and/or issues in console formatter

### DIFF
--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -76,6 +76,18 @@ final class AnalyseDefinition extends BaseDefinition
                 InputOption::VALUE_NONE,
                 'Flush cache results before processing'
             ),
+            new InputOption(
+                'summary-only',
+                null,
+                InputOption::VALUE_NONE,
+                'Only show the summary. This option only applies to the console formatter.'
+            ),
+            new InputOption(
+                'issues-only',
+                null,
+                InputOption::VALUE_NONE,
+                'Only show the issues. This option only applies to the console formatter.'
+            ),
         ]);
 
         return $definition;

--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -104,6 +104,11 @@ final class Console implements Formatter
 
     private Configuration $config;
 
+    private bool $showSummary = true;
+
+    private bool $showIssues = true;
+
+
     public function __construct(InputInterface $input, OutputInterface $output)
     {
         $this->style = new Style($input, $output);
@@ -114,6 +119,13 @@ final class Console implements Formatter
 
         $this->fileLinkFormatter = $this->config->getFileLinkFormatter();
         $this->supportHyperLinks = method_exists($outputFormatterStyle, 'setHref');
+
+        if ($input->getOption('summary-only')) {
+            $this->showIssues = false;
+        }
+        if ($input->getOption('issues-only')) {
+            $this->showSummary = false;
+        }
     }
 
     /**
@@ -125,6 +137,7 @@ final class Console implements Formatter
     {
         $results = $insightCollection->results();
 
+<<<<<<< HEAD
         $this->summary($results, $insightCollection->getCollector()->getAnalysedPaths())
             ->code($insightCollection, $results)
             ->complexity($insightCollection, $results)
@@ -135,6 +148,18 @@ final class Console implements Formatter
 
         if ($this->config->hasFixEnabled()) {
             $this->formatFix($insightCollection, $metrics);
+=======
+        if ($this->showSummary) {
+            $this->summary($results, $dir)
+                ->code($insightCollection, $results)
+                ->complexity($insightCollection, $results)
+                ->architecture($insightCollection, $results)
+                ->miscellaneous($results);
+        }
+
+        if ($this->showIssues) {
+            $this->issues($insightCollection, $metrics, $dir);
+>>>>>>> feat: Allow hiding summary and/or issues in console formatter
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #400 

This PR addresses the initial feature request of #400. I tried to implement @olivernybroe 's suggestion but run into a design issue where I would have to pass the `InputOption`s to the `InsightsCollectionFactory`. It felt really weird having the same parameter control what is analysed and how it's formatted. I feel a separate `--metrics` parameter would make much more sense.