### PR TITLE
Fix SyntaxCheck launch with windows on large project

### DIFF
--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -15,6 +15,8 @@ use Symfony\Component\Finder\Finder;
  */
 final class LocalFilesRepository implements FilesRepository
 {
+    public const DEFAULT_EXCLUDE = ['vendor', 'tests', 'Tests', 'test', 'Test'];
+
     private Finder $finder;
 
     /**
@@ -83,7 +85,7 @@ final class LocalFilesRepository implements FilesRepository
         $this->finder = Finder::create()
             ->files()
             ->name(['*.php'])
-            ->exclude(['vendor', 'tests', 'Tests', 'test', 'Test'])
+            ->exclude(self::DEFAULT_EXCLUDE)
             ->notName(['*.blade.php'])
             ->ignoreUnreadableDirs()
             ->in($this->directoryList ?? [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (on dev-master)
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

While @ekvedaras was testing parallelization on windows, a new bug came out (cf https://github.com/nunomaduro/phpinsights/pull/414#issuecomment-688075910) 

When we are launching SyntaxCheck on a large project with Windows, passing all files to inspect as arg may create a too long command for this system.

![image](https://user-images.githubusercontent.com/3168281/93667752-8d386100-fa88-11ea-88b0-414ec9db4d13.png)


Here, I refact how we launch it. Instead passing all files as arg, we now excludes directory or files from configuration, and pass the current analysed path.

![image](https://user-images.githubusercontent.com/3168281/93667781-b3f69780-fa88-11ea-8e7f-58f98ebbce74.png)
