### PR TITLE
Refs #438 - Fix exception thrown when no internet connection

### DIFF
--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -33,7 +33,7 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails, Globa
 
     public function process(): void
     {
-        $this->getResult();
+        $this->getDetails();
     }
 
     public function getDetails(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #438 

The getDetails method already handle catch InternetConnectionNotFound 
