### PR TITLE
Fix ComposerLoader when composer:V2 is installed globally

### DIFF
--- a/src/Domain/ComposerLoader.php
+++ b/src/Domain/ComposerLoader.php
@@ -9,6 +9,7 @@ use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Json\JsonFile;
 use Composer\Package\Locker;
+use Composer\Repository\RepositoryManager;
 
 /**
  * @internal
@@ -28,20 +29,32 @@ final class ComposerLoader
             $io = new NullIO();
             $composerPath = ComposerFinder::getPath($collector);
             self::$composer = (new Factory())->createComposer($io, ComposerFinder::getPath($collector), false, null, false);
-
-            $lockFile = pathinfo($composerPath, PATHINFO_EXTENSION) === 'json'
-                ? substr($composerPath, 0, -4).'lock'
-                : $composerPath . '.lock';
-
-            $composerContent = file_get_contents($composerPath);
-            if ($composerContent === false) {
-                throw new \InvalidArgumentException('Unable to get content of ' . $composerPath);
-            }
-
-            $locker = new Locker($io, new JsonFile($lockFile, null, $io), self::$composer->getRepositoryManager(), self::$composer->getInstallationManager(), $composerContent);
-            self::$composer->setLocker($locker);
+            self::$composer->setLocker(self::getLocker($composerPath, $io));
         }
 
         return self::$composer;
+    }
+
+    private static function getLocker(string $composerPath, NullIO $io): Locker
+    {
+        if (self::$composer === null) {
+            throw new \RuntimeException('Cannot get locker until composer is not initialized');
+        }
+        $lockFile = pathinfo($composerPath, PATHINFO_EXTENSION) === 'json'
+            ? substr($composerPath, 0, -4).'lock'
+            : $composerPath . '.lock';
+
+        $composerContent = file_get_contents($composerPath);
+        if ($composerContent === false) {
+            throw new \InvalidArgumentException('Unable to get content of ' . $composerPath);
+        }
+
+        $lockerConstructor = new \ReflectionMethod(Locker::class, '__construct');
+
+        // In composer v2, RepositoryManager is no longer needed
+        /** @phpstan-ignore-next-line */
+        return $lockerConstructor->getParameters()[2]->getType()->getName() === RepositoryManager::class
+            ? new Locker($io, new JsonFile($lockFile, null, $io), self::$composer->getRepositoryManager(), self::$composer->getInstallationManager(), $composerContent)
+            : new Locker($io, new JsonFile($lockFile, null, $io), self::$composer->getInstallationManager(), $composerContent); /** @phpstan-ignore-line */
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I was working on add compat with php8 and migrate CI to github action (you can see progress [here](https://github.com/Jibbarth/phpinsights/pull/1)) when composer v2 was released, and all my builds breaks :sweat_smile: 

![image](https://user-images.githubusercontent.com/3168281/97081428-b5286080-1602-11eb-9adf-984418ba1266.png)

After investigating, an fullload option is passed in createComposer when calling `Factory::create` to retrieve a Composer object, and this fullLoad option use somewhere the global composer binary...

I change the way to call ComposerFactory, to avoid having this `fullLoad` option to true, and I create manually the Locker (it was only created with fullLoad on true before).

