### PR TITLE
Fix changing formatter

### DIFF
--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -110,9 +110,6 @@ final class Console implements Formatter
         $this->totalWidth = (new Terminal())->getWidth();
 
         $outputFormatterStyle = new OutputFormatterStyle();
-        $this->config = Container::make()->get(Configuration::class);
-
-        $this->fileLinkFormatter = $this->config->getFileLinkFormatter();
         $this->supportHyperLinks = method_exists($outputFormatterStyle, 'setHref');
     }
 
@@ -123,6 +120,9 @@ final class Console implements Formatter
      */
     public function format(InsightCollection $insightCollection, array $metrics): void
     {
+        $this->config = Container::make()->get(Configuration::class);
+        $this->fileLinkFormatter = $this->config->getFileLinkFormatter();
+
         $results = $insightCollection->results();
 
         $this->summary($results, $insightCollection->getCollector()->getAnalysedPaths())

--- a/src/Application/Console/Formatters/FormatResolver.php
+++ b/src/Application/Console/Formatters/FormatResolver.php
@@ -27,7 +27,6 @@ final class FormatResolver
         OutputInterface $consoleOutput
     ): Formatter {
         $requestedFormats = $input->getOption('format');
-
         if (! is_array($requestedFormats)) {
             $consoleOutput->writeln(
                 '<fg=red>Could not understand requested format, using fallback [console] instead.</>'
@@ -40,8 +39,11 @@ final class FormatResolver
         foreach ($requestedFormats as $requestedFormat) {
             try {
                 $formatter = self::stringToFormatterClass($requestedFormat);
+                $formatterConstructor = new \ReflectionMethod($formatter, '__construct');
 
-                $instance = new $formatter($input, $output);
+                $instance = $formatterConstructor->getNumberOfParameters() === 1
+                    ? new $formatter($output)
+                    : new $formatter($input, $output);
 
                 if (! ($instance instanceof Formatter)) {
                     $consoleOutput->writeln(

--- a/src/Application/Console/Formatters/GithubAction.php
+++ b/src/Application/Console/Formatters/GithubAction.php
@@ -35,7 +35,6 @@ final class GithubAction implements Formatter
     {
         $this->decorated = new Console($input, $output);
         $this->output = $output;
-        $this->baseDir = Container::make()->get(Configuration::class)->getCommonPath();
     }
 
     /**
@@ -45,6 +44,8 @@ final class GithubAction implements Formatter
      */
     public function format(InsightCollection $insightCollection, array $metrics): void
     {
+        $this->baseDir = Container::make()->get(Configuration::class)->getCommonPath();
+
         // Call The Console Formatter to get summary and recap,
         // not issues by passing an empty array for metrics.
         $this->decorated->format($insightCollection, []);

--- a/tests/Application/Console/Formatters/FormatResolverTest.php
+++ b/tests/Application/Console/Formatters/FormatResolverTest.php
@@ -14,7 +14,6 @@ use NunoMaduro\PhpInsights\Application\Console\Formatters\Json;
 use NunoMaduro\PhpInsights\Application\Console\Formatters\Multiple;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/tests/Application/Console/Formatters/FormatResolverTest.php
+++ b/tests/Application/Console/Formatters/FormatResolverTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Console\Formatters;
+
+use NunoMaduro\PhpInsights\Application\Console\Contracts\Formatter;
+use NunoMaduro\PhpInsights\Application\Console\Definitions\AnalyseDefinition;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\Checkstyle;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\Console;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\FormatResolver;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\GithubAction;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\Json;
+use NunoMaduro\PhpInsights\Application\Console\Formatters\Multiple;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class FormatResolverTest extends TestCase
+{
+    private OutputInterface $output;
+    private OutputInterface $consoleOutput;
+
+    protected function setUp(): void
+    {
+        $this->output = new NullOutput();
+        $this->consoleOutput = new NullOutput();
+    }
+
+    public function testItCreateAConsoleFormatterByDefault(): void
+    {
+        $input = new ArrayInput([], AnalyseDefinition::get());
+
+        $formatter = FormatResolver::resolve($input, $this->output, $this->consoleOutput);
+
+        self::assertInstanceOf(Multiple::class, $formatter);
+        $formatters = $this->getFormattersInMultiple($formatter);
+        self::assertCount(1, $formatters);
+        self::assertInstanceOf(Console::class, $formatters[0]);
+    }
+
+    public function testItCreateAConsoleFormatter(): void
+    {
+        $input = new ArrayInput(['--format' => ['console']], AnalyseDefinition::get());
+        $formatter = FormatResolver::resolve($input, $this->output, $this->consoleOutput);
+
+        self::assertInstanceOf(Multiple::class, $formatter);
+        $formatters = $this->getFormattersInMultiple($formatter);
+        self::assertCount(1, $formatters);
+        self::assertInstanceOf(Console::class, $formatters[0]);
+    }
+
+
+    public function testItCreateAJsonFormatter(): void
+    {
+        $input = new ArrayInput(['--format' => ['json']], AnalyseDefinition::get());
+
+        $formatter = FormatResolver::resolve($input, $this->output, $this->consoleOutput);
+
+        self::assertInstanceOf(Multiple::class, $formatter);
+        $formatters = $this->getFormattersInMultiple($formatter);
+        self::assertCount(1, $formatters);
+        self::assertInstanceOf(Json::class, $formatters[0]);
+    }
+
+    public function testItCreateACheckstyleFormatter(): void
+    {
+        $input = new ArrayInput(['--format' => ['checkstyle']], AnalyseDefinition::get());
+
+        $formatter = FormatResolver::resolve($input, $this->output, $this->consoleOutput);
+        self::assertInstanceOf(Multiple::class, $formatter);
+        $formatters = $this->getFormattersInMultiple($formatter);
+        self::assertCount(1, $formatters);
+        self::assertInstanceOf(Checkstyle::class, $formatters[0]);
+    }
+
+    public function testItCreateAGithubActionFormatter(): void
+    {
+        $input = new ArrayInput(['--format' => ['github-action']], AnalyseDefinition::get());
+
+        $formatter = FormatResolver::resolve($input, $this->output, $this->consoleOutput);
+
+        self::assertInstanceOf(Multiple::class, $formatter);
+        $formatters = $this->getFormattersInMultiple($formatter);
+        self::assertCount(1, $formatters);
+        self::assertInstanceOf(GithubAction::class, $formatters[0]);
+    }
+
+    public function testItCreateMultipleFormatters(): void
+    {
+        $input = new ArrayInput(['--format' => ['console', 'checkstyle', 'github-action']], AnalyseDefinition::get());
+
+        $formatter = FormatResolver::resolve($input, $this->output, $this->consoleOutput);
+
+        self::assertInstanceOf(Multiple::class, $formatter);
+        $formatters = $this->getFormattersInMultiple($formatter);
+        self::assertCount(3, $formatters);
+        self::assertInstanceOf(Console::class, $formatters[0]);
+        self::assertInstanceOf(Checkstyle::class, $formatters[1]);
+        self::assertInstanceOf(GithubAction::class, $formatters[2]);
+    }
+
+    /**
+     * @return array<Formatter>
+     */
+    private function getFormattersInMultiple(Formatter $formatter): array
+    {
+        assert($formatter instanceof Multiple);
+        $refProperty = new \ReflectionProperty($formatter, 'formatters');
+        $refProperty->setAccessible(true);
+
+        return $refProperty->getValue($formatter);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

I noticed we can no longer use `json` or `checkstyle` formatter cause their constructors changed in #391 

This PR fix that by looking with a reflection how many parameters has formatter. 

I also added tests to avoid future regression on this :sweat_smile: 
