### PR TITLE
Replace Packagist API call with Enlightn Security Checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
         "composer/composer": "^1.7",
+        "enlightn/security-checker": "^1.4",
         "friendsofphp/php-cs-fixer": "^2.15",
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",
@@ -32,8 +33,7 @@
         "slevomat/coding-standard": "^6.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/console": "^4.2|^5.0",
-        "symfony/finder": "^4.2|^5.0",
-        "symfony/http-client": "^4.3|^5.0"
+        "symfony/finder": "^4.2|^5.0"
     },
     "require-dev": {
         "illuminate/console": "^5.8|^6.0|^7.0",

--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -4,26 +4,24 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
-use Composer\Semver\Semver;
+use Enlightn\SecurityChecker\SecurityChecker;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Exceptions\ComposerNotFound;
 use NunoMaduro\PhpInsights\Domain\Exceptions\InternetConnectionNotFound;
-use Symfony\Component\HttpClient\HttpClient;
+use Throwable;
 
 final class ForbiddenSecurityIssues extends Insight implements HasDetails
 {
-    private const PACKAGIST_ADVISORIES_URL = 'https://repo.packagist.org/api/security-advisories/';
+    /**
+     * @var array
+     */
+    private static $result;
 
     /**
      * @var array<Details>
      */
     private static $details;
-
-    public function __destruct()
-    {
-        self::$details = null;
-    }
 
     public function hasIssue(): bool
     {
@@ -42,7 +40,7 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails
         }
 
         try {
-            $this->getResult();
+            $issues = $this->getResult();
         } catch (InternetConnectionNotFound $exception) {
             self::$details = [
                 Details::make()->setMessage($exception->getMessage()),
@@ -50,10 +48,23 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails
             return self::$details;
         }
 
+        if (empty($issues)) {
+            return [];
+        }
+
+        self::$details = [];
+        foreach ($issues as $packageName => $package) {
+            foreach ($package['advisories'] as $advisory) {
+                self::$details[] = Details::make()->setMessage(
+                    "${packageName}@v{$package['version']} {$advisory['title']} - {$advisory['link']}"
+                );
+            }
+        }
+
         return self::$details;
     }
 
-    private function getResult(): void
+    private function getResult(): array
     {
         $composerPath = sprintf('%s/composer.lock', $this->collector->getDir());
 
@@ -61,66 +72,16 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails
             throw new ComposerNotFound('composer.lock not found. Try launch composer install');
         }
 
-        $packages = json_decode(file_get_contents($composerPath), true);
-        $packagesToCheck = array_combine(
-            array_map(static function (array $detail): string {
-                return $detail['name'];
-            }, $packages['packages']),
-            array_map(static function (array $detail): string {
-                return $detail['version'];
-            }, $packages['packages'])
-        );
-
-        $advisoryList = $this->retrieveAdvisoriesListForPackages(array_keys($packagesToCheck));
-
-        self::$details = [];
-        $packagesToCheck = array_filter(
-            $packagesToCheck,
-            static function (string $packageName) use ($advisoryList): bool {
-                return \array_key_exists($packageName, $advisoryList['advisories']);
-            },
-            ARRAY_FILTER_USE_KEY
-        );
-
-        foreach ($packagesToCheck as $packageName => $version) {
-            $issues = $advisoryList['advisories'][$packageName];
-
-            $this->addIssuesDetails($packageName, $version, $issues);
-        }
-    }
-
-    private function retrieveAdvisoriesListForPackages(array $packagesName): array
-    {
-        $client = HttpClient::create();
-
-        $chunks = array_chunk($packagesName, 30);
-        $responses = [];
-        // Launch async requests
-        foreach ($chunks as $packages) {
-            $responses[] = $client->request('GET', self::PACKAGIST_ADVISORIES_URL, [
-                'query' => ['packages' => $packages],
-            ]);
-        }
-
-        $advisories = [];
-        /** @var \Symfony\Contracts\HttpClient\ResponseInterface $response */
-        foreach ($responses as $response) {
-            $advisories[] = $response->toArray()['advisories'];
-        }
-        $allAdvisories = array_merge([], ...$advisories);
-
-        return ['advisories' => $allAdvisories];
-    }
-
-    private function addIssuesDetails(string $packageName, string $version, array $issues): void
-    {
-        foreach ($issues as $issue) {
-            if (false === Semver::satisfies($version, $issue['affectedVersions'])) {
-                continue;
-            }
-            self::$details[] = Details::make()->setMessage(
-                "${packageName}@{$version} {$issue['title']} - {$issue['link']}"
+        try {
+            self::$result = (new SecurityChecker)->check($composerPath);
+        } catch (Throwable $e) {
+            throw new InternetConnectionNotFound(
+                'PHP Insights needs an internet connection to inspect security issues.',
+                1,
+                $e
             );
         }
+
+        return self::$result;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Followup PR to https://github.com/nunomaduro/phpinsights/pull/453.

This PR replaces the native Packagist API call with the [Enlightn Security Checker](https://github.com/enlightn/security-checker).

**Benefits of this PR include**:

1. Reduce maintenance burden of API calls, etc. and lets an independent package handle this. Other packages such as [GrumPHP](https://github.com/phpro/grumphp/) are also moving to the Enlightn security checker as it is almost a drop-in replacement to the earlier Sensiolabs security checker.
2. It has built-in HTTP caching, so is more efficient than the API calls to Packagist.

This is my first PR to PHP Insights, so let me know if you'd like me to make any changes.

WDYT?