### PR TITLE
[CI] Avoid launch on modified file if not a PR

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -49,6 +49,7 @@ jobs:
               run: composer run rector:test -- --dry-run
 
             - name: PHPInsight on modified files
+              if: github.event_name == 'pull_request'
               run: |
                   URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
                   FILES=$(curl -s -X GET -G $URL | jq -r '.[] |  select( .status == "added" or .status == "modified") | .filename')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

This avoid to launch PHP Insight with list of modified file when it's not a pull request workflow.

