### PR TITLE
[Cyclomatic Complexity] Improvements

### DIFF
--- a/phpinsights.php
+++ b/phpinsights.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use NunoMaduro\PhpInsights\Domain\Insights\CyclomaticComplexityIsHigh;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenDefineGlobalConstants;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenTraits;
 use NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff;
@@ -101,6 +102,11 @@ return [
         ForbiddenTraits::class => [
             'exclude' => [
                 'src/Domain/Insights/FixPerFileCollector.php',
+            ],
+        ],
+        CyclomaticComplexityIsHigh::class => [
+            'exclude' => [
+                'src/Domain/Analyser.php',
             ],
         ],
     ],

--- a/src/Domain/Collector.php
+++ b/src/Domain/Collector.php
@@ -214,7 +214,7 @@ final class Collector
 
     public function currentMethodStop(string $name): void
     {
-        $this->methodComplexity[] = $this->currentMethodComplexity;
+        $this->methodComplexity[$this->currentFilename . ':' . $name] = $this->currentMethodComplexity;
         $this->methodLines[$this->currentFilename . ':' . $name] = $this->currentMethodLines;
     }
 
@@ -772,6 +772,25 @@ final class Collector
     public function getConstants(): int
     {
         return \count($this->getGlobalConstants()) + $this->getClassConstants();
+    }
+
+    /**
+     * @param array<string, \SplFileInfo> $excludedFiles
+     */
+    public function excludeComplexityFiles(array $excludedFiles): void
+    {
+        foreach (array_keys($this->methodComplexity) as $fileMethod) {
+            $file = explode(':', $fileMethod, 2);
+            if (array_key_exists($file[0], $excludedFiles)) {
+                unset($this->methodComplexity[$fileMethod]);
+            }
+        }
+
+        foreach (array_keys($this->classComplexity) as $file) {
+            if (array_key_exists($file, $excludedFiles)) {
+                unset($this->classComplexity[$file]);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #458, #422, #367

Hi :wave: 

This PR to add some improvement for Cyclomatic Complexity. 

First, as pointed in #458, the Insight title still appear even if we exclude all problematic files in config. 
This is because the hasIssue method didn't take account of getDetails method. 

Then, I added in the collector a way to remove from complexity calc all files excluded. 
In effect, when we DECIDE to exclude a file, the calculator SHOULD don't take it in account.

**Note for users:** 
To get 100points in complexity score, you need to have an averrage cyclomatic complexity of 1.00. 
So even you raise maxComplexity limit, your score is caclculated on the averrage cyclomatic complexity, and your score will not change. 
But with this fix, you should be able to *exclude* files you don't want to affect your score.