### PR TITLE
fix: Convert Checkstyle's source attribute to dot notation format

### DIFF
--- a/src/Application/Console/Formatters/Checkstyle.php
+++ b/src/Application/Console/Formatters/Checkstyle.php
@@ -65,9 +65,9 @@ final class Checkstyle implements Formatter
 
                     $error = $file->addChild('error');
                     $error->addAttribute('severity', 'error');
-                    $error->addAttribute('source', $insight->getTitle());
+                    $error->addAttribute('source', str_replace('\\', '.', $insight->getInsightClass()));
                     $error->addAttribute('line', $detail->hasLine() ? (string) $detail->getLine() : '');
-                    $error->addAttribute('message', $detail->hasMessage() ? $detail->getMessage() : '');
+                    $error->addAttribute('message', $detail->hasMessage() ? $detail->getMessage() : $insight->getTitle());
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #463 

Convert "source" attribute in Checkstyle report to dot notation.
Apply the change as advised in https://github.com/nunomaduro/phpinsights/issues/463#issuecomment-791896035

This will allow Checkstyle parsing tools to get the category and type of the issue.

The checkstyle output before
```
<error severity="error" source="Forbidden setter" line="227"
               message="Setters are not allowed. Use constructor injection and behavior naming instead."/>
```
and after the change
```
<error severity="error" source="NunoMaduro.PhpInsights.Domain.Sniffs.ForbiddenSetterSniff" line="227"
               message="Setters are not allowed. Use constructor injection and behavior naming instead."/>
```

Also Jenkins Warnings Next Generation Plugin UI looks much better now
![image](https://user-images.githubusercontent.com/25210529/110533067-975c2380-80eb-11eb-8caf-bac106000d73.png)

