### PR TITLE
Change Symfony console `InputOption` default value from int to string

### DIFF
--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -22,28 +22,28 @@ final class AnalyseDefinition extends BaseDefinition
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Minimal Quality level to reach without throw error',
-                0
+                '0'
             ),
             new InputOption(
                 'min-complexity',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Minimal Complexity level to reach without throw error',
-                0
+                '0'
             ),
             new InputOption(
                 'min-architecture',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Minimal Architecture level to reach without throw error',
-                0
+                '0'
             ),
             new InputOption(
                 'min-style',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Minimal Style level to reach without throw error',
-                0
+                '0'
             ),
             new InputOption(
                 'disable-security-check',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

It seems the signature of `InputOption` has been changed from `string|string[]|int|bool|null` to `string|string[]|bool|null` in the latest release.

Reference: https://github.com/symfony/console/commit/3c65c2dda22b7794dde8dd5e0c2f7b5542ae0d2c

This PR will fix this issue by passing a string instead of an integer.