### PR TITLE
Update a composer dev dependency to avoid failure on PHP v.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/http-client": "^4.3|^5.0"
     },
     "require-dev": {
-        "ergebnis/phpstan-rules": "^0.14.0",
+        "ergebnis/phpstan-rules": "^0.15.0",
         "illuminate/console": "^5.8|^6.0|^7.0|^8.0",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no


Currently installing `PhpInsights` dev dependencies is not possible on PHP v.8 and you'll get the below error:
  
```
Problem 1
    - ergebnis/phpstan-rules[0.14.0, ..., 0.14.1] require php ^7.2 -> your php version (8.0.1) does not satisfy that requirement.
    - ergebnis/phpstan-rules[0.14.2, ..., 0.14.4] require php ^7.1 -> your php version (8.0.1) does not satisfy that requirement.
    - Root composer.json requires ergebnis/phpstan-rules ^0.14.0 -> satisfiable by ergebnis/phpstan-rules[0.14.0, ..., 0.14.4].
```

So we need to bump the dependency version up to allow this package to install on PHP v.8.

Reference: https://github.com/ergebnis/phpstan-rules/pull/294