### PR TITLE
Github workflow - Remove ignore-platform-reqs in composer install

### DIFF
--- a/.github/workflows/standalone.yaml
+++ b/.github/workflows/standalone.yaml
@@ -47,7 +47,7 @@ jobs:
                   tools: composer:${{ matrix.composer-version }}
 
             - name: Install Composer dependencies
-              run: composer update --${{ matrix.dependency-version }} --ansi  --no-interaction --prefer-dist --no-dev --ignore-platform-reqs
+              run: composer update --${{ matrix.dependency-version }} --ansi  --no-interaction --prefer-dist --no-dev
 
             - name: Test launching phpinsights
               run: php bin/phpinsights analyse --ansi -v --no-interaction --disable-security-check --flush-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,6 @@ jobs:
                   tools: composer:${{ matrix.composer-version }}
 
             - name: Install Composer dependencies
-              run: composer update --${{ matrix.dependency-version }} --ansi --no-interaction --prefer-dist --ignore-platform-reqs
+              run: composer update --${{ matrix.dependency-version }} --ansi --no-interaction --prefer-dist
             - name: Unit Tests
               run: vendor/bin/phpunit --color=always


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

The symfony/cache-contract v2.4.0 (released yesterday https://github.com/symfony/cache-contracts/releases/tag/v2.4.0) enable v2 and v3 of psr/cache, that require php8.0. 

As we had some composer install `ignore-platform-reqs`, all build are broken :sweat_smile: .

Let's see if we remove it fix all stuff :crossed_fingers: 


<!--
- Replace this comment by a description of what your PR is solving.
-->
