### PR TITLE
[Feature] Add option to show summary only

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -58,3 +58,6 @@ jobs:
             - name: PHPInsight
               run: composer run insights
 
+            - name: PHPInsight - Summary only
+              run: composer run insights -- --summary
+

--- a/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
+++ b/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
@@ -20,8 +20,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
  */
 final class InsightsCommand extends Command
 {
-    /** @var array<int, string> */
-    const FUNDING_MESSAGES = [
+    private const FUNDING_MESSAGES = [
         '  - Star or contribute to PHP Insights:',
         '    <options=bold>https://github.com/nunomaduro/phpinsights</>',
         '  - Sponsor the maintainers:',

--- a/src/Application/Console/Commands/InvokableCommand.php
+++ b/src/Application/Console/Commands/InvokableCommand.php
@@ -12,8 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class InvokableCommand extends BaseCommand
 {
-    /** @var array<int, string> */
-    const FUNDING_MESSAGES = [
+    private const FUNDING_MESSAGES = [
         '  - Star or contribute to PHP Insights:',
         '    <options=bold>https://github.com/nunomaduro/phpinsights</>',
         '  - Sponsor the maintainers:',

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -76,12 +76,6 @@ final class AnalyseDefinition extends BaseDefinition
                 InputOption::VALUE_NONE,
                 'Flush cache results before processing'
             ),
-            new InputOption(
-                'summary',
-                's',
-                InputOption::VALUE_NONE,
-                'Display summary only',
-            ),
         ]);
 
         return $definition;

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -76,6 +76,12 @@ final class AnalyseDefinition extends BaseDefinition
                 InputOption::VALUE_NONE,
                 'Flush cache results before processing'
             ),
+            new InputOption(
+                'summary',
+                's',
+                InputOption::VALUE_NONE,
+                'Display summary only',
+            ),
         ]);
 
         return $definition;

--- a/src/Application/Console/Definitions/BaseDefinition.php
+++ b/src/Application/Console/Definitions/BaseDefinition.php
@@ -29,6 +29,12 @@ abstract class BaseDefinition
                 InputOption::VALUE_OPTIONAL,
                 'The configuration file path'
             ),
+            new InputOption(
+                'summary',
+                's',
+                InputOption::VALUE_NONE,
+                'Display summary only',
+            ),
         ]);
     }
 }

--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -105,9 +105,15 @@ final class Console implements Formatter
 
     private Configuration $config;
 
+    private bool $summaryOnly = false;
+
     public function __construct(InputInterface $input, OutputInterface $output)
     {
         $this->style = new Style($input, $output);
+
+        if ($input->hasOption('summary')) {
+            $this->summaryOnly = (bool) $input->getOption('summary');
+        }
         $this->totalWidth = (new Terminal())->getWidth();
 
         $outputFormatterStyle = new OutputFormatterStyle();
@@ -131,6 +137,10 @@ final class Console implements Formatter
             ->complexity($insightCollection, $results)
             ->architecture($insightCollection, $results)
             ->miscellaneous($results);
+
+        if ($this->summaryOnly) {
+            return;
+        }
 
         $this->issues($insightCollection, $metrics, $insightCollection->getCollector()->getCommonPath());
 

--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -138,11 +138,9 @@ final class Console implements Formatter
             ->architecture($insightCollection, $results)
             ->miscellaneous($results);
 
-        if ($this->summaryOnly) {
-            return;
+        if (! $this->summaryOnly) {
+            $this->issues($insightCollection, $metrics, $insightCollection->getCollector()->getCommonPath());
         }
-
-        $this->issues($insightCollection, $metrics, $insightCollection->getCollector()->getCommonPath());
 
         if ($this->config->hasFixEnabled()) {
             $this->formatFix($insightCollection, $metrics);
@@ -185,9 +183,9 @@ final class Console implements Formatter
         }
 
         $this->style->success(sprintf('🧙 ️Congrats ! %s %s', $totalFix, $message));
-        $this->style->writeln(sprintf('<fg=yellow;options=bold>%s issues remaining</>', $totalIssues));
-        $this->style->newLine();
-
+        if ($this->summaryOnly) {
+            $metrics = [];
+        }
         foreach ($metrics as $metricClass) {
             $category = explode('\\', $metricClass);
             $category = $category[count($category) - 2];
@@ -222,6 +220,7 @@ final class Console implements Formatter
             }
         }
 
+        $this->style->writeln(sprintf('<fg=yellow;options=bold>%s issues remaining</>', $totalIssues));
         $this->style->newLine();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

:wave: 

A little tiny feature that enable to only show summary. 

It could be usefull when, for example, you want to display a real-time monitor while you code. 

See video below :wink: 

https://user-images.githubusercontent.com/3168281/116463767-625a8a80-a86b-11eb-9ae7-e69b27bb74ca.mp4

If you want reproduce this, I used the `watch` command : 

```bash
watch -c -b php vendor/bin/phpinsights -s --ansi
```

With this PR, I also improve the `fix` output: Display first the recap, then files fixed, then total issues remaining. I think it's less confusing.  
