### PR TITLE
[Feature] Diff output configurable

### DIFF
--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -62,7 +62,7 @@ jobs:
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Launch PHPInsights
               working-directory: ./project
-              run: php vendor/bin/phpinsights -n --ansi
+              run: php vendor/bin/phpinsights -n --disable-security-check --ansi
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Launch PHPInsights Fixer
               working-directory: ./project
@@ -131,9 +131,9 @@ jobs:
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Launch PHPInsights
               working-directory: ./project
-              run: php artisan insights --ansi
+              run: php artisan insights -n --disable-security-check --ansi
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Launch PHPInsights Fixer
               working-directory: ./project
-              run: php artisan insights --ansi --fix
+              run: php artisan insights -n --ansi --fix --disable-security-check
               continue-on-error: ${{ env.allow_failure == 'true' }}

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -178,3 +178,18 @@ composer bin phpinsights require nunomaduro/phpinsights
 
 Between 2 analysis, issues are cached. 
 PHPInsights is smart enough to invalidate cache when it detect changes in your code, but you may completly flush cache before analysis by adding `--flush-cache` flag.
+
+## Configure diff <Badge text="^2.0"/>
+
+Some insights display a diff output.
+If you want more context on the diff, configure it in the `phpinsights.php` file:
+
+```php
+<?php
+
+return [
+    // ...
+    'diff_context' => 3,
+    // ...
+];
+```

--- a/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
+++ b/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
@@ -10,6 +10,7 @@ use NunoMaduro\PhpInsights\Application\Console\Commands\AnalyseCommand;
 use NunoMaduro\PhpInsights\Application\Console\Definitions\AnalyseDefinition;
 use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Container;
+use NunoMaduro\PhpInsights\Domain\Exceptions\InvalidConfiguration;
 use NunoMaduro\PhpInsights\Domain\Kernel;
 use NunoMaduro\PhpInsights\Domain\Reflection;
 use RuntimeException;
@@ -47,7 +48,17 @@ final class InsightsCommand extends Command
          * @noRector Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector
          */
         $configuration['fix'] = $this->hasOption('fix') && (bool) $this->option('fix') === true;
-        $configuration = ConfigResolver::resolve($configuration, $this->input);
+        try {
+            $configuration = ConfigResolver::resolve($configuration, $this->input);
+        } catch (InvalidConfiguration $exception) {
+            $this->output->writeln([
+                '',
+                '  <bg=red;options=bold> Invalid configuration </>',
+                '    <fg=red>•</> <options=bold>' . $exception->getMessage() . '</>',
+                '',
+            ]);
+            return 1;
+        }
 
         $container = Container::make();
         if (! $container instanceof \League\Container\Container) {

--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -627,6 +627,8 @@ final class Console implements Formatter
             $detailString = '';
 
             foreach (explode(PHP_EOL, $detail->getMessage()) as $line) {
+                $detailString .= PHP_EOL;
+
                 if (mb_strpos($line, '-') === 0) {
                     $hasColor = true;
                     $detailString .= '<fg=red>';
@@ -637,7 +639,7 @@ final class Console implements Formatter
                     $detailString .= '<fg=green>';
                 }
 
-                $detailString .= OutputFormatter::escape($line) . PHP_EOL;
+                $detailString .= OutputFormatter::escape($line);
 
                 if ($hasColor) {
                     $hasColor = false;

--- a/src/Application/Injectors/Configuration.php
+++ b/src/Application/Injectors/Configuration.php
@@ -9,8 +9,10 @@ use NunoMaduro\PhpInsights\Application\Console\Commands\InternalProcessorCommand
 use NunoMaduro\PhpInsights\Application\Console\Definitions\DefinitionBinder;
 use NunoMaduro\PhpInsights\Domain\Configuration as DomainConfiguration;
 use NunoMaduro\PhpInsights\Domain\Container;
+use NunoMaduro\PhpInsights\Domain\Exceptions\InvalidConfiguration;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
  * @internal
@@ -52,7 +54,18 @@ final class Configuration
 
                 $config['fix'] = $fixOption || $input->getFirstArgument() === 'fix';
 
-                return ConfigResolver::resolve($config, $input);
+                try {
+                    return ConfigResolver::resolve($config, $input);
+                } catch (InvalidConfiguration $exception) {
+                    (new ConsoleOutput())->getErrorOutput()
+                        ->writeln([
+                            '',
+                            '  <bg=red;options=bold> Invalid configuration </>',
+                            '    <fg=red>•</> <options=bold>' . $exception->getMessage() . '</>',
+                            '',
+                        ]);
+                    die(1);
+                }
             },
         ];
     }

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -275,9 +275,14 @@ final class Configuration
         $resolver->setAllowedValues('requirements', $this->validateRequirements());
         $resolver->setAllowedTypes('threads', ['null', 'int']);
         $resolver->setAllowedTypes('diff_context', 'int');
+        $resolver->setAllowedValues('diff_context', static fn ($value) => $value >= 0);
         $resolver->setAllowedValues('threads', static fn ($value) => $value === null || $value >= 1);
 
-        $config = $resolver->resolve($config);
+        try {
+            $config = $resolver->resolve($config);
+        } catch (\Throwable $throwable) {
+            throw new InvalidConfiguration($throwable->getMessage(), $throwable->getCode(), $throwable);
+        }
 
         $this->preset = $config['preset'];
 

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -106,6 +106,8 @@ final class Configuration
 
     private int $threads;
 
+    private int $diffContext;
+
     /**
      * Configuration constructor.
      *
@@ -237,6 +239,11 @@ final class Configuration
         return $this->threads;
     }
 
+    public function getDiffContext(): int
+    {
+        return $this->diffContext;
+    }
+
     /**
      * @param array<string, string|int|array|null> $config
      */
@@ -253,6 +260,7 @@ final class Configuration
             'remove' => [],
             'config' => [],
             'fix' => false,
+            'diff_context' => 1,
         ]);
 
         $resolver->setDefined('ide');
@@ -266,6 +274,7 @@ final class Configuration
         $resolver->setAllowedValues('config', $this->validateConfigInsights());
         $resolver->setAllowedValues('requirements', $this->validateRequirements());
         $resolver->setAllowedTypes('threads', ['null', 'int']);
+        $resolver->setAllowedTypes('diff_context', 'int');
         $resolver->setAllowedValues('threads', static fn ($value) => $value === null || $value >= 1);
 
         $config = $resolver->resolve($config);
@@ -286,6 +295,7 @@ final class Configuration
         $this->config = $config['config'];
         $this->requirements = $config['requirements'];
         $this->fix = $config['fix'];
+        $this->diffContext = $config['diff_context'];
 
         if (array_key_exists('ide', $config)
             && is_string($config['ide'])

--- a/src/Domain/Differ.php
+++ b/src/Domain/Differ.php
@@ -14,10 +14,12 @@ final class Differ implements DifferInterface
 
     public function __construct()
     {
+        $diffContext = Container::make()->get(Configuration::class)->getDiffContext();
+
         $outputBuilder = new StrictUnifiedDiffOutputBuilder([
             'collapseRanges' => true,
             'commonLineThreshold' => 1,
-            'contextLines' => 0,
+            'contextLines' => $diffContext,
             'fromFile' => '',
             'toFile' => '',
         ]);

--- a/src/Domain/Insights/FixerDecorator.php
+++ b/src/Domain/Insights/FixerDecorator.php
@@ -133,7 +133,7 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
 
     public function addDiff(string $file, string $diff): void
     {
-        $diff = substr($diff, 8);
+        $diff = trim(substr($diff, 8));
 
         $this->errors[] = Details::make()->setFile($file)->setDiff($diff)->setMessage($diff);
     }

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Tests\Fakes\FakeInput;
 
 final class ConfigResolverTest extends TestCase
@@ -27,7 +26,6 @@ final class ConfigResolverTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-
         $this->baseFixturePath = dirname(__DIR__) . DIRECTORY_SEPARATOR .
             'Fixtures' . DIRECTORY_SEPARATOR . 'ConfigResolver' . DIRECTORY_SEPARATOR;
     }
@@ -124,7 +122,7 @@ final class ConfigResolverTest extends TestCase
 
     public function testUnknownPresetThrowException(): void
     {
-        $this->expectException(InvalidOptionsException::class);
+        $this->expectException(InvalidConfiguration::class);
 
         $config = ['preset' => 'UnknownPreset'];
 

--- a/tests/Domain/ConfigurationTest.php
+++ b/tests/Domain/ConfigurationTest.php
@@ -119,7 +119,7 @@ final class ConfigurationTest extends TestCase
      */
     public function testExceptionOnInvalidSetThread($invalid): void
     {
-        $this->expectException(\Symfony\Component\OptionsResolver\Exception\InvalidOptionsException::class);
+        $this->expectException(InvalidConfiguration::class);
         $this->expectExceptionMessage('The option "threads" with value');
         new Configuration(['threads' => $invalid]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

:wave: 

This PR to improve display for diff. 

By default, I add 1 line of context around the diff. I also improve the default display by removing some empty lines.

**Before:**
![image](https://user-images.githubusercontent.com/3168281/116779217-4b878400-aa75-11eb-80cb-032560af8d6d.png)

**After:**
![image](https://user-images.githubusercontent.com/3168281/116779239-66f28f00-aa75-11eb-95f4-0e033c456195.png)

But, now, we can configure the diff context around. 

In `phpinsights.php`, add the following line: 

```php
<?php

return [
    // ...
    'diff_context' => 3,
]
```

**Output:**

![image](https://user-images.githubusercontent.com/3168281/116779299-c6e93580-aa75-11eb-9341-40f62e79b966.png)

While testing, I noticed that when configuration file has some invalid options, the output was really ugly: 

![image](https://user-images.githubusercontent.com/3168281/116779351-319a7100-aa76-11eb-80e0-c504151028f0.png)

I rework a little this part to improve output when there is an invalid configuration:

![image](https://user-images.githubusercontent.com/3168281/116779403-935adb00-aa76-11eb-8682-12d79094df7c.png)

