### PR TITLE
Use correct config key for new FunctionLengthSniff

### DIFF
--- a/docs/insights/architecture.md
+++ b/docs/insights/architecture.md
@@ -166,7 +166,7 @@ This sniff checks the size of functions
 
 ```php
 \SlevomatCodingStandard\Sniffs\Files\FunctionLengthSniff::class => [
-    'maxLength' => 20,
+    'maxLinesLength' => 20,
 ]
 ```
 </details>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #483 

Use correct config key for FunctionLengthSniff as per [FunctionLengthSniff.php:44](https://github.com/slevomat/coding-standard/blob/0012151f0f0fc33709472667368c568dffda2839/SlevomatCodingStandard/Sniffs/Functions/FunctionLengthSniff.php#L44)