### PR TITLE
[SyntaxCheck] Fix `exclude`s from config/preset not being applied

### DIFF
--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -38,34 +38,20 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
     public function process(): void
     {
-        $phpPath = (string) Config::getExecutablePath('php');
-
-        $binary = sprintf(
-            '%s %s',
-            escapeshellcmd($phpPath),
-            escapeshellarg($this->vendorParentPathFind() . '/vendor/bin/parallel-lint')
-        );
-        if (DIRECTORY_SEPARATOR === '\\') {
-            $binary = $this->vendorParentPathFind() . '\vendor\bin\parallel-lint.bat';
-        }
-
-        $toAnalyse = '.';
-        if (\count($this->collector->getFiles()) === 1) {
-            // We ask to analyse one file, just proceed it
-            $files = $this->collector->getFiles();
-            $toAnalyse = \array_pop($files);
-        } elseif (rtrim($this->collector->getCommonPath(), DIRECTORY_SEPARATOR) !== getcwd()) {
-            $toAnalyse = $this->collector->getCommonPath();
-        }
+        $toAnalyse = $this->getTarget();
 
         $cmdLine = sprintf(
             '%s --no-colors --no-progress --json %s %s',
-            $binary,
+            $this->getBinary(),
             implode(' ', $this->getShellExcludeArgs()),
             $toAnalyse
         );
 
         $process = Process::fromShellCommandline($cmdLine);
+
+        if ($toAnalyse === '.' && getcwd() !== rtrim($this->collector->getCommonPath(), DIRECTORY_SEPARATOR)) {
+            $process->setWorkingDirectory($this->collector->getCommonPath());
+        }
         $process->run();
 
         $output = json_decode($process->getOutput(), true, 512, JSON_THROW_ON_ERROR);
@@ -81,6 +67,21 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
         }
     }
 
+    private function getBinary(): string
+    {
+        $parentPath = $this->vendorParentPathFind();
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            return $parentPath . '\vendor\bin\parallel-lint.bat';
+        }
+
+        return sprintf(
+            '%s %s',
+            escapeshellcmd((string) Config::getExecutablePath('php')),
+            escapeshellarg($parentPath . '/vendor/bin/parallel-lint')
+        );
+    }
+
     /**
      * @return array<string>
      */
@@ -94,6 +95,17 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
             static fn (string $file): string => '--exclude ' . escapeshellarg($file),
             array_merge($rootExcludes, $this->excludedFiles, LocalFilesRepository::DEFAULT_EXCLUDE)
         );
+    }
+
+    private function getTarget(): string
+    {
+        $files = $this->collector->getFiles();
+
+        if (count($files) === 1) {
+            return \array_pop($files);
+        }
+
+        return '.';
     }
 
     private function vendorParentPathFind(): string

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -83,6 +83,9 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
     }
 
     /**
+     * Converts all sources of excluded files into a list of escaped `--exclude` args for parallel-lint.
+     * This insight uses paths as-is rather than resolving them, As parallel-lint resolves paths itself.
+     *
      * @return array<string>
      */
     private function getShellExcludeArgs(): array
@@ -90,10 +93,11 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
         $configuration = Container::make()->get(Configuration::class);
 
         $rootExcludes = $configuration->getExcludes();
+        $localExcludes = $this->config['exclude'] ?? [];
 
         return array_map(
             static fn (string $file): string => '--exclude ' . escapeshellarg($file),
-            array_merge($rootExcludes, $this->excludedFiles, LocalFilesRepository::DEFAULT_EXCLUDE)
+            array_merge($rootExcludes, $localExcludes, LocalFilesRepository::DEFAULT_EXCLUDE)
         );
     }
 

--- a/tests/Domain/Insights/Fixtures/InvalidPhpCode/_ide_helper.php
+++ b/tests/Domain/Insights/Fixtures/InvalidPhpCode/_ide_helper.php
@@ -1,0 +1,7 @@
+<?php
+namespace {
+    class Container extends \League\Container\Container {};
+}
+namespace {
+    use League\Container\Container;
+}

--- a/tests/Domain/Insights/SyntaxCheckTest.php
+++ b/tests/Domain/Insights/SyntaxCheckTest.php
@@ -35,6 +35,7 @@ final class SyntaxCheckTest extends TestCase
     public function testHasIssueOnDirectory(): void
     {
         $basepath = __DIR__ . '/Fixtures/InvalidPhpCode';
+
         /** @var \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection $insights */
         $insights = $this->runAnalyserOnPreset(
             'default',
@@ -44,11 +45,15 @@ final class SyntaxCheckTest extends TestCase
 
         foreach ($insights->all() as $insight) {
             if ($insight instanceof SyntaxCheck) {
-                self::assertTrue($insight->hasIssue());
-                self::assertCount(3, $insight->getDetails());
-
                 $details = $insight->getDetails();
                 usort($details, static fn (Details $a, Details $b): int => $a->getFile() <=> $b->getFile());
+
+                self::assertTrue($insight->hasIssue());
+                if (PHP_MAJOR_VERSION === 7) {
+                    self::assertCount(2, $details);
+                } else {
+                    self::assertCount(3, $details);
+                }
 
                 /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */
                 $detail = $details[0];

--- a/tests/Domain/Insights/SyntaxCheckTest.php
+++ b/tests/Domain/Insights/SyntaxCheckTest.php
@@ -52,4 +52,25 @@ final class SyntaxCheckTest extends TestCase
             }
         }
     }
+
+    public function testExcludesPathsFromPreset(): void
+    {
+        $basepath = __DIR__ . '/Fixtures/InvalidPhpCode';
+
+        /** @var \NunoMaduro\PhpInsights\Domain\Insights\InsightCollection $insights */
+        $insights = $this->runAnalyserOnPreset(
+            'laravel',
+            [$basepath . '/_ide_helper.php', $basepath . '/UnclosedComment.php'],
+            [$basepath] // simulate analysing a project directory
+        );
+
+        foreach ($insights->all() as $insight) {
+            if ($insight instanceof SyntaxCheck) {
+                self::assertTrue($insight->hasIssue());
+                $detail = $insight->getDetails()[0];
+                self::assertStringNotContainsString('Fixtures/InvalidPhpCode/_ide_helper.php', $detail->getFile());
+                self::assertStringNotContainsString('PHP syntax error: Cannot use League\\Container', $detail->getMessage());
+            }
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #486


This fixes a few issues with SyntaxCheck introduced in #437 and #448 that together resulted in files from the config's top-level `exclude` option not being excluded.


### Config
```php
return ['preset' => 'laravel', 'exclude' => ['foo.php']];
```

### Before
```sh
/usr/bin/php '/foo/vendor/bin/parallel-lint' --no-colors --no-progress --json \
  --exclude 'vendor' --exclude 'tests' --exclude 'Tests' --exclude 'test' --exclude 'Test' .
```

### After
```sh
/usr/bin/php '/foo/vendor/bin/parallel-lint' --no-colors --no-progress --json \
  --exclude 'bower_components' --exclude 'node_modules' --exclude 'vendor' --exclude '.phpstorm.meta.php' \
  --exclude 'config' --exclude 'storage' --exclude 'resources' --exclude 'bootstrap' --exclude 'nova' \
  --exclude 'database' --exclude 'server.php' --exclude '_ide_helper.php' --exclude '_ide_helper_models.php' \
  --exclude 'app/Providers/TelescopeServiceProvider.php' --exclude 'public' \
  --exclude 'vendor' --exclude 'tests' --exclude 'Tests' --exclude 'test' --exclude 'Test' .
```

Fixes #486