### PR TITLE
Upgrade dependencies (PHP-CS-Fixer v3)

### DIFF
--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -59,7 +59,7 @@ jobs:
             - name: Install PHPInsights
               working-directory: ./project
               run: composer require --dev "nunomaduro/phpinsights:*" -n --ansi
-              continue-on-error: ${{ env.allow_failure == 'true' }}
+              continue-on-error: true
             - name: Launch PHPInsights
               working-directory: ./project
               run: php vendor/bin/phpinsights -n --disable-security-check --ansi

--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -15,7 +15,7 @@ jobs:
                 os: [ubuntu-latest]
                 version: ['^4.4', '@stable', '@dev'] # Test current LTS, current release, and future release
                 php: ['7.4', '8.0']
-                composer-version: [v1, v2]
+                composer-version: [v2]
                 exclude:
                     - version: '^4.4'
                       php: '8.0'
@@ -44,7 +44,6 @@ jobs:
               run: |
                   composer config name phpinsights/symfony-tester
                   composer config description "Symfony test"
-                  composer require composer/composer:^${{ matrix.composer-version }}
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Linking library
               working-directory: ./project
@@ -77,7 +76,7 @@ jobs:
                 os: [ubuntu-latest]
                 version: ['^7.0', '^8.0']
                 php: ['7.4', '8.0']
-                composer-version: [v1, v2]
+                composer-version: [v2]
                 exclude:
                     - version: '^7.0'
                       php: '8.0'

--- a/.github/workflows/standalone.yaml
+++ b/.github/workflows/standalone.yaml
@@ -15,7 +15,7 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
                 php: ['7.4', '8.0']
                 dependency-version: [prefer-lowest, prefer-stable]
-                composer-version: [v1, v2]
+                composer-version: [v2]
                 exclude:
                     -   dependency-version: prefer-lowest
                         php: '8.0'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
             matrix:
                 php: ['7.4', '8.0']
                 dependency-version: [prefer-lowest, prefer-stable]
-                composer-version: [ v1, v2 ]
+                composer-version: [ v2 ]
                 exclude:
                     -   dependency-version: prefer-lowest
                         php: '8.0'

--- a/bin/phpinsights
+++ b/bin/phpinsights
@@ -6,6 +6,13 @@ declare(strict_types=1);
 use NunoMaduro\PhpInsights\Domain\Kernel;
 use Symfony\Component\Console\Application;
 
+if (!defined('T_MATCH')) {
+    // Avoid conflict using php-codesniffer and php-cs-fixer together.
+    // codesniffer register this constant with string, cs-fixer v3 expect it as int
+    // @TODO: Drop when require PHP8.0+
+    define('T_MATCH', 341);
+}
+
 (static function () {
     require file_exists(__DIR__ . '/../vendor/autoload.php')
         ? __DIR__ . '/../vendor/autoload.php'

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "composer/composer": "^1.7 || ^2.0",
-        "friendsofphp/php-cs-fixer": "^2.16.1",
+        "composer/composer": "^2.0.14",
+        "friendsofphp/php-cs-fixer": "^3.0.0",
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",
         "php-parallel-lint/php-parallel-lint": "^1.3",
@@ -44,7 +44,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^8.0|^9.0",
-        "rector/rector": "^0.10.6",
+        "rector/rector": "^0.11.2",
         "symfony/var-dumper": "^4.2|^5.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
@@ -108,7 +108,6 @@
     "scripts-descriptions": {
         "website:copy-changelog": "Copy package changelog to the website",
         "website:copy-logo": "Copy logo from art directory to the website",
-        "ecs:test": "Run the ecs tests.",
         "rector:test": "Run the rector tests.",
         "phpstan:test": "Run the phpstan tests.",
         "phpunit:test": "Run the phpunit tests.",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "composer/composer": "^2.0.14",
+        "composer/composer": "^1.7 || ^2.0",
         "friendsofphp/php-cs-fixer": "^3.0.0",
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "composer/composer": "^1.7 || ^2.0",
+        "composer/composer": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0.0",
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",
@@ -109,10 +109,11 @@
         "website:copy-changelog": "Copy package changelog to the website",
         "website:copy-logo": "Copy logo from art directory to the website",
         "rector:test": "Run the rector tests.",
+        "csfixer:test": "Run the PhpCsFixer tests.",
         "phpstan:test": "Run the phpstan tests.",
         "phpunit:test": "Run the phpunit tests.",
         "insights": "Run the phpinsights tests",
-        "test": "Run all tests including phpstan, phpunit and ecs.",
+        "test": "Run all tests including phpstan, phpunit and phpcs.",
         "fix": "Run ecs, phpinsights and rector fixers."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     "scripts": {
         "website:copy-changelog": "@php -r \"copy('CHANGELOG.md', 'docs/changelog.md');\"",
         "website:copy-logo": "@php -r \"(is_dir('docs/.vuepress/public') || mkdir('docs/.vuepress/public')) && copy('art/logo_mixed.gif', 'docs/.vuepress/public/logo.gif') && copy('art/heart.svg', 'docs/.vuepress/public/heart.svg') && copy('art/heart.png', 'docs/.vuepress/public/heart.png');\"",
-        "csfixer:test": "php-cs-fixer fix -v --diff-format udiff",
+        "csfixer:test": "php-cs-fixer fix -v",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",
         "rector:test": "rector process --ansi",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,7 +53,7 @@ parameters:
             message: "#^Parameter \\#.* of class Composer\\\\Package\\\\Locker constructor expects .*$#"
             count: 3
             path: src/Domain/ComposerLoader.php
-
+        - "#^Parameter \\#1 \\$input of function array_flip expects array\\<int\\|string\\>, array\\<string, array\\|float\\|int\\|string\\> given\\.$#"
     bootstrapFiles:
         - %rootDir%/../../squizlabs/php_codesniffer/autoload.php
     reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,6 +42,7 @@ parameters:
             message: '#generic class ReflectionClass#'
             path: src/Domain/Reflection.php
         - '#NunoMaduro\\PhpInsights\\Domain\\File::addFixableError#'
+        - '#NunoMaduro\\PhpInsights\\Domain\\Differ#'
         - '#iterable type PhpCsFixer\\Tokenizer\\Tokens#'
         - '#Method NunoMaduro\\PhpInsights\\Application\\Console\\Definitions\\BaseDefinition::get\(\) is not final#'
         -

--- a/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
+++ b/src/Application/Adapters/Laravel/Commands/InsightsCommand.php
@@ -44,9 +44,6 @@ final class InsightsCommand extends Command
         }
 
         $configuration = require $configPath;
-        /**
-         * @noRector Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector
-         */
         $configuration['fix'] = $this->hasOption('fix') && (bool) $this->option('fix') === true;
         try {
             $configuration = ConfigResolver::resolve($configuration, $this->input);

--- a/src/Application/Injectors/Configuration.php
+++ b/src/Application/Injectors/Configuration.php
@@ -47,9 +47,6 @@ final class Configuration
                     $config = require $configPath;
                 }
 
-                /**
-                 * @noRector Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector
-                 */
                 $fixOption = $input->hasOption('fix') && (bool) $input->getOption('fix') === true;
 
                 $config['fix'] = $fixOption || $input->getFirstArgument() === 'fix';

--- a/src/Domain/ComposerLoader.php
+++ b/src/Domain/ComposerLoader.php
@@ -9,7 +9,6 @@ use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Json\JsonFile;
 use Composer\Package\Locker;
-use Composer\Repository\RepositoryManager;
 
 /**
  * @internal

--- a/src/Domain/ComposerLoader.php
+++ b/src/Domain/ComposerLoader.php
@@ -49,12 +49,6 @@ final class ComposerLoader
             throw new \InvalidArgumentException('Unable to get content of ' . $composerPath);
         }
 
-        $lockerConstructor = new \ReflectionMethod(Locker::class, '__construct');
-
-        // In composer v2, RepositoryManager is no longer needed
-        /** @phpstan-ignore-next-line */
-        return $lockerConstructor->getParameters()[2]->getType()->getName() === RepositoryManager::class
-            ? new Locker($io, new JsonFile($lockFile, null, $io), self::$composer->getRepositoryManager(), self::$composer->getInstallationManager(), $composerContent)
-            : new Locker($io, new JsonFile($lockFile, null, $io), self::$composer->getInstallationManager(), $composerContent);
+        return new Locker($io, new JsonFile($lockFile, null, $io), self::$composer->getInstallationManager(), $composerContent);
     }
 }

--- a/src/Domain/Differ.php
+++ b/src/Domain/Differ.php
@@ -32,6 +32,6 @@ final class Differ implements DifferInterface
      */
     public function diff(string $old, string $new, ?\SplFileInfo $file = null): string
     {
-        return $this->differ->diff($old, $new);
+        return $this->differ->diff($old, $new, $file);
     }
 }

--- a/src/Domain/Differ.php
+++ b/src/Domain/Differ.php
@@ -32,6 +32,6 @@ final class Differ implements DifferInterface
      */
     public function diff(string $old, string $new, ?\SplFileInfo $file = null): string
     {
-        return $this->differ->diff($old, $new, $file);
+        return $this->differ->diff($old, $new);
     }
 }

--- a/src/Domain/Differ.php
+++ b/src/Domain/Differ.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain;
 
-use PhpCsFixer\Diff\v3_0\Differ as BaseDiffer;
-use PhpCsFixer\Diff\v3_0\Output\StrictUnifiedDiffOutputBuilder;
+use PhpCsFixer\Diff\Differ as BaseDiffer;
+use PhpCsFixer\Diff\Output\StrictUnifiedDiffOutputBuilder;
 use PhpCsFixer\Differ\DifferInterface;
 
 final class Differ implements DifferInterface
@@ -30,7 +30,7 @@ final class Differ implements DifferInterface
     /**
      * {@inheritdoc}
      */
-    public function diff($old, $new): string
+    public function diff(string $old, string $new, ?\SplFileInfo $file = null): string
     {
         return $this->differ->diff($old, $new);
     }

--- a/src/Domain/Insights/FixerDecorator.php
+++ b/src/Domain/Insights/FixerDecorator.php
@@ -10,6 +10,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\Insight as InsightContract;
 use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\Helper\Files;
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
@@ -145,5 +146,10 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
             return false;
         }
         return isset($this->exclude[$path]);
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        // TODO: Implement getDefinition() method.
     }
 }

--- a/src/Domain/Insights/FixerDecorator.php
+++ b/src/Domain/Insights/FixerDecorator.php
@@ -150,6 +150,6 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
 
     public function getDefinition(): FixerDefinitionInterface
     {
-        // TODO: Implement getDefinition() method.
+        return $this->fixer->getDefinition();
     }
 }

--- a/src/Domain/Insights/FixerDecorator.php
+++ b/src/Domain/Insights/FixerDecorator.php
@@ -139,6 +139,11 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
         $this->errors[] = Details::make()->setFile($file)->setDiff($diff)->setMessage($diff);
     }
 
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return $this->fixer->getDefinition();
+    }
+
     private function skipFilesFromExcludedFiles(SplFileInfo $file): bool
     {
         $path = $file->getRealPath();
@@ -146,10 +151,5 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
             return false;
         }
         return isset($this->exclude[$path]);
-    }
-
-    public function getDefinition(): FixerDefinitionInterface
-    {
-        return $this->fixer->getDefinition();
     }
 }

--- a/src/Domain/Metrics/Style/Style.php
+++ b/src/Domain/Metrics/Style/Style.php
@@ -63,7 +63,6 @@ use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\StandardizeNotEqualsFixer;
 use PhpCsFixer\Fixer\Phpdoc\AlignMultilineCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
-use PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer;
 use PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer;
@@ -181,7 +180,6 @@ final class Style implements HasInsights
             SingleQuoteFixer::class,
             StandardizeNotEqualsFixer::class,
             PhpdocIndentFixer::class,
-            PhpdocInlineTagFixer::class,
             PhpdocTrimFixer::class,
             PhpdocVarAnnotationCorrectOrderFixer::class,
             SingleClassElementPerStatementFixer::class,

--- a/src/Domain/Metrics/Style/Style.php
+++ b/src/Domain/Metrics/Style/Style.php
@@ -63,6 +63,7 @@ use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\StandardizeNotEqualsFixer;
 use PhpCsFixer\Fixer\Phpdoc\AlignMultilineCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagNormalizerFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocVarAnnotationCorrectOrderFixer;
 use PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer;
@@ -180,6 +181,7 @@ final class Style implements HasInsights
             SingleQuoteFixer::class,
             StandardizeNotEqualsFixer::class,
             PhpdocIndentFixer::class,
+            PhpdocInlineTagNormalizerFixer::class,
             PhpdocTrimFixer::class,
             PhpdocVarAnnotationCorrectOrderFixer::class,
             SingleClassElementPerStatementFixer::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #476

This PR will close #476. 

- As @Jibbarth said here https://github.com/nunomaduro/phpinsights/issues/476#issuecomment-838825297, due to replacing `php-cs-fixer` and `php-codesniffer` by `symplify/easy-coding-standard`, I believe we need to remove it. 
- `php-cs-fixer` in version 3.0 is using `"composer/xdebug-handler": "^2.0"`, and composer in version 2.0 is still using `"composer/xdebug-handler": "^1.1"`. So, we need to wait for new release of composer.
- There are some changes in the new version are `Rector` that have been applied.
- There are some changes in `php-cs-fixer` interfaces that need to be applied.