### PR TITLE
[Fix] Continuous Integration fixes

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -42,8 +42,8 @@ jobs:
             - name: PHPStan
               run: composer run phpstan:test -- --error-format=checkstyle | cs2pr
 
-            - name: ECS
-              run: composer run ecs:test
+            - name: PHP CS Fixer
+              run: composer run csfixer:test -- --dry-run
 
             - name: Rector
               run: composer run rector:test -- --dry-run

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,20 @@
+<?php
+
+$config = new PhpCsFixer\Config();
+return $config
+    ->setUsingCache(false)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_empty_statement' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unneeded_curly_braces' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => true,
+        'protected_to_private' => true,
+    ])
+    ->setFinder(PhpCsFixer\Finder::create()
+        ->in(__DIR__ . '/src/')
+    )
+;

--- a/composer.json
+++ b/composer.json
@@ -80,20 +80,20 @@
     "scripts": {
         "website:copy-changelog": "@php -r \"copy('CHANGELOG.md', 'docs/changelog.md');\"",
         "website:copy-logo": "@php -r \"(is_dir('docs/.vuepress/public') || mkdir('docs/.vuepress/public')) && copy('art/logo_mixed.gif', 'docs/.vuepress/public/logo.gif') && copy('art/heart.svg', 'docs/.vuepress/public/heart.svg') && copy('art/heart.png', 'docs/.vuepress/public/heart.png');\"",
-        "ecs:test": "ecs check src --ansi --config vendor/symplify/easy-coding-standard/config/set/clean-code.php",
+        "csfixer:test": "php-cs-fixer fix -v --diff-format udiff",
         "phpstan:test": "phpstan analyse --ansi",
         "phpunit:test": "phpunit --colors=always",
         "rector:test": "rector process --ansi",
         "insights": "bin/phpinsights analyse --ansi -v --no-interaction",
         "test": [
             "@phpstan:test",
-            "@ecs:test",
+            "@csfixer:test --dry-run",
             "@rector:test --dry-run",
             "@phpunit:test",
             "@insights"
         ],
         "fix": [
-            "@ecs:test --fix",
+            "@csfixer:test",
             "@insights --fix --quiet",
             "@rector:test"
         ],

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "friendsofphp/php-cs-fixer": "^2.16.1",
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2",
-        "php-parallel-lint/php-parallel-lint": "^1.1",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phploc/phploc": "^5.0|^6.0|^7.0",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "phpunit/phpunit": "^8.0|^9.0",
         "rector/rector": "^0.10.6",
         "symfony/var-dumper": "^4.2|^5.0",
-        "symplify/easy-coding-standard": "^9.1",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
     "suggest": {

--- a/rector.php
+++ b/rector.php
@@ -27,19 +27,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // Path to phpstan with extensions, that PHPSTan in Rector uses to determine types
     //$parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, getcwd() . '/phpstan.neon.dist');
 
-    $parameters->set(Option::SETS, [
-        SetList::ARRAY_STR_FUNCTIONS_TO_STATIC_CALL,
-        SetList::CODE_QUALITY,
-        SetList::DEAD_CODE,
-        SetList::DOCTRINE_CODE_QUALITY,
-        SetList::EARLY_RETURN,
-        SetList::PHP_71,
-        SetList::PHP_72,
-        SetList::PHP_73,
-        SetList::PHP_74,
-        SetList::PHPUNIT_CODE_QUALITY,
-    ]);
+    $containerConfigurator->import(SetList::CODE_QUALITY);
+    $containerConfigurator->import(SetList::DEAD_CODE);
+    $containerConfigurator->import(SetList::EARLY_RETURN);
+    $containerConfigurator->import(SetList::PHP_71);
+    $containerConfigurator->import(SetList::PHP_72);
+    $containerConfigurator->import(SetList::PHP_73);
+    $containerConfigurator->import(SetList::PHP_74);
+
     $parameters->set(Option::SKIP, [
         \Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector::class,
+        \Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector::class,
     ]);
 };

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -95,7 +95,8 @@ final class Runner
             );
 
             // process them
-            array_walk($filesCached,
+            array_walk(
+                $filesCached,
                 function (SplFileInfo $file): void {
                     $this->processFile($file);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Hi :wave: 

This PR fix the continuous integrations : 

* update the min dependency for php-parallel-lint, as there is a problem launching it in lowest version in a directory without composer.json
* Replace the ecs code set by creating a php-cs-fixer config file
* Upgrade rector conf thanks to @50bhan 

