### PR TITLE
Accept slevomat/coding-standard ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "object-calisthenics/phpcs-calisthenics-rules": "^3.7",
         "phploc/phploc": "^5.0|^6.0",
         "psr/container": "^1.0",
-        "slevomat/coding-standard": "^6.0",
+        "slevomat/coding-standard": "^6.0|^7.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/console": "^4.2|^5.0",
         "symfony/finder": "^4.2|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

I'm trying to install the lib in my project but I'm with those conflicts

```
Problem 1
    - Conclusion: don't install nunomaduro/phpinsights v1.14.1
    - Conclusion: don't install nunomaduro/phpinsights v1.14.0
    - Conclusion: remove phpstan/phpdoc-parser 0.5.4
    - Installation request for nunomaduro/phpinsights ^1.13 -> satisfiable by nunomaduro/phpinsights[v1.13.0, v1.14.0, v1.14.1].
    - Conclusion: don't install phpstan/phpdoc-parser 0.5.4
    - nunomaduro/phpinsights v1.13.0 requires slevomat/coding-standard ^6.0 -> satisfiable by slevomat/coding-standard[6.0.0, 6.0.1, 6.0.2, 6.0.3, 6.0.4, 6.0.5, 6.0.6, 6.0.7, 6.0.8, 6.1.0, 6.1.1, 6.1.2, 6.1.3, 6.1.4, 6.1.5, 6.2.0, 6.3.0, 6.3.1, 6.3.10, 6.3.11, 6.3.2, 6.3.3, 6.3.4, 6.3.5, 6.3.6, 6.3.7, 6.3.8, 6.3.9, 6.4.0, 6.4.1].
    - slevomat/coding-standard 6.2.0 requires phpstan/phpdoc-parser 0.4.0 - 0.4.3 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3].
    - slevomat/coding-standard 6.3.0 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.1 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.10 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.2 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.3 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.4 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.5 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.6 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.7 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.8 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.9 requires phpstan/phpdoc-parser 0.4.0 - 0.4.4 -> satisfiable by phpstan/phpdoc-parser[0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4].
    - slevomat/coding-standard 6.3.11 requires phpstan/phpdoc-parser 0.4.5 - 0.4.9 -> satisfiable by phpstan/phpdoc-parser[0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.4.9].
    - slevomat/coding-standard 6.4.0 requires phpstan/phpdoc-parser 0.4.5 - 0.4.9 -> satisfiable by phpstan/phpdoc-parser[0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.4.9].
    - slevomat/coding-standard 6.4.1 requires phpstan/phpdoc-parser 0.4.5 - 0.4.9 -> satisfiable by phpstan/phpdoc-parser[0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.4.9].
    - slevomat/coding-standard 6.0.0 requires phpstan/phpdoc-parser 0.3.5 - 0.4.0 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0].
    - slevomat/coding-standard 6.0.1 requires phpstan/phpdoc-parser 0.3.5 - 0.4.1 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1].
    - slevomat/coding-standard 6.0.2 requires phpstan/phpdoc-parser 0.3.5 - 0.4.1 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1].
    - slevomat/coding-standard 6.0.3 requires phpstan/phpdoc-parser 0.3.5 - 0.4.1 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1].
    - slevomat/coding-standard 6.0.4 requires phpstan/phpdoc-parser 0.3.5 - 0.4.1 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1].
    - slevomat/coding-standard 6.0.5 requires phpstan/phpdoc-parser 0.3.5 - 0.4.2 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2].
    - slevomat/coding-standard 6.0.6 requires phpstan/phpdoc-parser 0.3.5 - 0.4.2 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2].
    - slevomat/coding-standard 6.0.7 requires phpstan/phpdoc-parser 0.3.5 - 0.4.2 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2].
    - slevomat/coding-standard 6.0.8 requires phpstan/phpdoc-parser 0.3.5 - 0.4.2 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2].
    - slevomat/coding-standard 6.1.0 requires phpstan/phpdoc-parser 0.3.5 - 0.4.2 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2].
    - slevomat/coding-standard 6.1.1 requires phpstan/phpdoc-parser 0.3.5 - 0.4.2 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2].
    - slevomat/coding-standard 6.1.2 requires phpstan/phpdoc-parser 0.3.5 - 0.4.3 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2, 0.4.3].
    - slevomat/coding-standard 6.1.3 requires phpstan/phpdoc-parser 0.3.5 - 0.4.3 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2, 0.4.3].
    - slevomat/coding-standard 6.1.4 requires phpstan/phpdoc-parser 0.3.5 - 0.4.3 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2, 0.4.3].
    - slevomat/coding-standard 6.1.5 requires phpstan/phpdoc-parser 0.3.5 - 0.4.3 -> satisfiable by phpstan/phpdoc-parser[0.3.5, 0.4.0, 0.4.1, 0.4.2, 0.4.3].
    - Can only install one of: phpstan/phpdoc-parser[0.4.0, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.1, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.2, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.3, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.4, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.5, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.6, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.7, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.8, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.4.9, 0.5.4].
    - Can only install one of: phpstan/phpdoc-parser[0.3.5, 0.5.4].
    - Installation request for phpstan/phpdoc-parser (locked at 0.5.4) -> satisfiable by phpstan/phpdoc-parser[0.5.4].
```

and I saw that in master you already accepting this version then I guess it's ok for this version too, I can't see any blocker ....
<!--
- Replace this comment by a description of what your PR is solving.
-->
