### PR TITLE
Feature: support configuring fixer indentation

### DIFF
--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -124,3 +124,12 @@ For example, to remove "Unused Parameters" Insight only for some file:
     ],
 ```
 
+<Badge text="^2.0"/> For insights that come from PHP-CS-Fixer and implements `WhitespacesAwareFixerInterface`, you can also configure the indentation to respect: 
+
+```php
+    'configure' => [
+        \PhpCsFixer\Fixer\Basic\BraceFixer::class => [
+            'indent' => '  ',
+		],
+    ],
+```

--- a/src/Domain/InsightLoader/FixerLoader.php
+++ b/src/Domain/InsightLoader/FixerLoader.php
@@ -9,8 +9,8 @@ use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Contracts\InsightLoader;
 use NunoMaduro\PhpInsights\Domain\Insights\FixerDecorator;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
-use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\WhitespacesFixerConfig;
 
 /**
@@ -39,7 +39,7 @@ final class FixerLoader implements InsightLoader
         }
 
         if (isset($config['indent'])) {
-            if ($fixer instanceof WhitespacesAwareFixerInterface) {
+            if ($fixer instanceof WhitespacesAwareFixerInterface && is_string($config['indent'])) {
                 $fixerConfig = new WhitespacesFixerConfig($config['indent']);
                 $fixer->setWhitespacesConfig($fixerConfig);
             }

--- a/src/Domain/InsightLoader/FixerLoader.php
+++ b/src/Domain/InsightLoader/FixerLoader.php
@@ -9,7 +9,9 @@ use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Contracts\InsightLoader;
 use NunoMaduro\PhpInsights\Domain\Insights\FixerDecorator;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\WhitespacesFixerConfig;
 
 /**
  * @internal
@@ -34,6 +36,15 @@ final class FixerLoader implements InsightLoader
             /** @var array<string> $excludeConfig */
             $excludeConfig = $config['exclude'];
             unset($config['exclude']);
+        }
+
+        if (isset($config['indent'])) {
+            if ($fixer instanceof WhitespacesAwareFixerInterface) {
+                $fixerConfig = new WhitespacesFixerConfig($config['indent']);
+                $fixer->setWhitespacesConfig($fixerConfig);
+            }
+
+            unset($config['indent']);
         }
 
         if ($fixer instanceof ConfigurableFixerInterface && count($config) > 0) {


### PR DESCRIPTION
This adds support for controlling the WhitespacesFixerConfig for fixers implementing WhitespacesAwareFixerInterface.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #451

This PR implements the second option discussed in #451 (Per fixer config).