### PR TITLE
Fix retrieving composer binary path in SyntaxCheck

### DIFF
--- a/src/Application/DefaultPreset.php
+++ b/src/Application/DefaultPreset.php
@@ -28,6 +28,7 @@ final class DefaultPreset implements PresetContract
                 'bower_components',
                 'node_modules',
                 'vendor',
+                'vendor-bin',
                 '.phpstorm.meta.php',
             ],
             'add' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | Fix #504

As @tarlepp indicate in #504, when we install phpinsights through bamarni composer plugin, the SyntaxCheck Insight is unable to find the correct path for using parallel-lint. 

This PR should fix that