### PR TITLE
docs: Change docker example to be more robust.

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -58,7 +58,7 @@ php artisan insights
 
 You can also use `phpinsights` via Docker:
 ```bash
-docker run -it --rm -v $(pwd):/app nunomaduro/phpinsights
+docker run -it --rm -v "$(pwd):/app" nunomaduro/phpinsights
 ```
 
 ## Analyse a sub-directory or a specific file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | no |

The docker example uses `pwd`, but it is not wrapped in quotes `"`.

If the path returned by `pwd` contains a space character, docker will have an error:

> docker: invalid reference format.

For people less familiar with docker, it can be quite unclear what is going wrong.

This MR fixes that issue by wrapping the call in quotes, so the path is passed to docker properly. 