### PR TITLE
[Docs] Upgrade to setup-php version 2

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -49,7 +49,7 @@ jobs:
         name: PHP Insights checks
         steps:
             - uses: actions/checkout@v2
-            - uses: shivammathur/setup-php@v1
+            - uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.3
             - run: composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | none

As version 1 is deprecated, we should use version 2 in the docs. 

There are no breaking changes if using GitHub Actions as shown in the docs.