### PR TITLE
Update the GitHub Actions example to PHP 8

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -51,7 +51,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: shivammathur/setup-php@v1
               with:
-                  php-version: 7.3
+                  php-version: 8.0
             - run: composer install --prefer-dist --no-progress --no-suggest
             - run: vendor/bin/phpinsights -n --ansi --format=github-action
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | none

Not a big deal. Not important, but as PHP 8 is supported, we could show the usage of PHP 8.0 in the docs.