### PR TITLE
[Rector] Apply Latest Rector 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^8.0|^9.0",
-        "rector/rector": "0.11.32",
+        "rector/rector": "0.11.47",
         "symfony/var-dumper": "^4.2|^5.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^8.0|^9.0",
-        "rector/rector": "0.11.47",
+        "rector/rector": "0.11.48",
         "symfony/var-dumper": "^4.2|^5.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^8.0|^9.0",
-        "rector/rector": "0.11.48",
+        "rector/rector": "0.11.56",
         "symfony/var-dumper": "^4.2|^5.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },

--- a/rector.php
+++ b/rector.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/bin']);
-    $parameters->set(Option::AUTOLOAD_PATHS, [
+    $parameters->set(Option::BOOTSTRAP_FILES, [
         __DIR__ . '/vendor/squizlabs/php_codesniffer/autoload.php',
     ]);
 
@@ -21,8 +22,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
     // skip classes used in PHP DocBlocks, like in /** @var \Some\Class */ [default: true]
     $parameters->set(Option::IMPORT_DOC_BLOCKS, false);
-    // Run Rector only on changed files
-    $parameters->set(Option::ENABLE_CACHE, true);
 
     // Path to phpstan with extensions, that PHPSTan in Rector uses to determine types
     //$parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, getcwd() . '/phpstan.neon.dist');
@@ -38,5 +37,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::SKIP, [
         \Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector::class,
         \Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector::class,
+        RemoveUnusedPromotedPropertyRector::class,
     ]);
 };

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -192,13 +192,13 @@ final class ConfigResolver
         $removedRulesByPreset = [];
         $addedRulesByConfig = [];
 
-        if (isset($preset['remove']) && is_array($preset['remove']) && count($preset['remove']) > 0) {
+        if (isset($preset['remove']) && is_array($preset['remove']) && $preset['remove'] !== []) {
             array_walk_recursive($preset['remove'], static function ($value) use (&$removedRulesByPreset): void {
                 $removedRulesByPreset[] = $value;
             });
         }
 
-        if (isset($config['add']) && is_array($config['add']) && count($config['add']) > 0) {
+        if (isset($config['add']) && is_array($config['add']) && $config['add'] !== []) {
             array_walk_recursive($config['add'], static function ($value) use (&$addedRulesByConfig): void {
                 $addedRulesByConfig[] = $value;
             });

--- a/src/Application/Console/Commands/InternalProcessorCommand.php
+++ b/src/Application/Console/Commands/InternalProcessorCommand.php
@@ -66,7 +66,7 @@ final class InternalProcessorCommand
         if (! \is_array($files)) {
             return 0;
         }
-        if (\count($files) === 0) {
+        if ($files === []) {
             return 0;
         }
 

--- a/src/Domain/Collector.php
+++ b/src/Domain/Collector.php
@@ -830,7 +830,7 @@ final class Collector
      */
     private function getMaximum(array $array)
     {
-        return \count($array) !== 0 ? \max($array) : 0;
+        return $array !== [] ? \max($array) : 0;
     }
 
     private function divide(float $x, float $y): float

--- a/src/Domain/File.php
+++ b/src/Domain/File.php
@@ -109,7 +109,7 @@ final class File extends BaseFile
         $severity,
         $isFixable = false
     ): bool {
-        $message = count($data) > 0 ? vsprintf($message, $data) : $message;
+        $message = $data !== [] ? vsprintf($message, $data) : $message;
 
         if ($isFixable && $this->isFixable) {
             if ($this->fixEnabled) {

--- a/src/Domain/InsightLoader/FixerLoader.php
+++ b/src/Domain/InsightLoader/FixerLoader.php
@@ -47,7 +47,7 @@ final class FixerLoader implements InsightLoader
             unset($config['indent']);
         }
 
-        if ($fixer instanceof ConfigurableFixerInterface && count($config) > 0) {
+        if ($fixer instanceof ConfigurableFixerInterface && $config !== []) {
             $fixer->configure($config);
         }
 

--- a/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
+++ b/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
@@ -21,6 +21,9 @@ final class ComposerLockMustBeFresh extends Insight implements HasDetails
             $composer = ComposerLoader::getInstance($this->collector);
             $locker = $composer->getLocker();
 
+            if (null === $locker) {
+                return true;
+            }
             if (! $locker->isLocked()) {
                 return true;
             }

--- a/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
+++ b/src/Domain/Insights/Composer/ComposerLockMustBeFresh.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights\Composer;
 
+use Composer\Package\Locker;
 use NunoMaduro\PhpInsights\Domain\ComposerLoader;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Details;
@@ -21,7 +22,7 @@ final class ComposerLockMustBeFresh extends Insight implements HasDetails
             $composer = ComposerLoader::getInstance($this->collector);
             $locker = $composer->getLocker();
 
-            if (null === $locker) {
+            if (! $locker instanceof Locker) {
                 return true;
             }
             if (! $locker->isLocked()) {

--- a/src/Domain/Insights/Composer/ComposerMustBeValid.php
+++ b/src/Domain/Insights/Composer/ComposerMustBeValid.php
@@ -31,7 +31,7 @@ final class ComposerMustBeValid extends Insight implements HasDetails
             $this->process();
         }
 
-        return count($this->details) > 0;
+        return $this->details !== [];
     }
 
     public function getTitle(): string

--- a/src/Domain/Insights/CyclomaticComplexityIsHigh.php
+++ b/src/Domain/Insights/CyclomaticComplexityIsHigh.php
@@ -20,7 +20,7 @@ final class CyclomaticComplexityIsHigh extends Insight implements HasDetails, Gl
 
     public function hasIssue(): bool
     {
-        return count($this->details) > 0;
+        return $this->details !== [];
     }
 
     public function getTitle(): string
@@ -39,7 +39,7 @@ final class CyclomaticComplexityIsHigh extends Insight implements HasDetails, Gl
     public function process(): void
     {
         // Exclude in collector all excluded files
-        if (count($this->excludedFiles) > 0) {
+        if ($this->excludedFiles !== []) {
             $this->collector->excludeComplexityFiles($this->excludedFiles);
         }
         $complexityLimit = $this->getMaxComplexity();

--- a/src/Domain/Insights/FixerDecorator.php
+++ b/src/Domain/Insights/FixerDecorator.php
@@ -45,7 +45,7 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
         $this->fixer = $fixer;
         $this->exclude = [];
 
-        if (count($exclude) > 0) {
+        if ($exclude !== []) {
             $this->exclude = Files::find($dir, $exclude);
         }
     }
@@ -93,7 +93,7 @@ final class FixerDecorator implements FixerInterface, InsightContract, DetailsCa
      */
     public function hasIssue(): bool
     {
-        return count($this->errors) !== 0;
+        return $this->errors !== [];
     }
 
     /**

--- a/src/Domain/Insights/ForbiddenDefineFunctions.php
+++ b/src/Domain/Insights/ForbiddenDefineFunctions.php
@@ -11,7 +11,7 @@ final class ForbiddenDefineFunctions extends Insight implements HasDetails
 {
     public function hasIssue(): bool
     {
-        return count($this->getDetails()) > 0;
+        return $this->getDetails() !== [];
     }
 
     public function getTitle(): string

--- a/src/Domain/Insights/ForbiddenDefineGlobalConstants.php
+++ b/src/Domain/Insights/ForbiddenDefineGlobalConstants.php
@@ -11,7 +11,7 @@ final class ForbiddenDefineGlobalConstants extends Insight implements HasDetails
 {
     public function hasIssue(): bool
     {
-        return count($this->getDetails()) > 0;
+        return $this->getDetails() !== [];
     }
 
     public function getTitle(): string

--- a/src/Domain/Insights/ForbiddenGlobals.php
+++ b/src/Domain/Insights/ForbiddenGlobals.php
@@ -14,7 +14,7 @@ final class ForbiddenGlobals extends Insight implements HasDetails
 {
     public function hasIssue(): bool
     {
-        return count($this->getDetails()) > 0;
+        return $this->getDetails() !== [];
     }
 
     public function getTitle(): string

--- a/src/Domain/Insights/ForbiddenNormalClasses.php
+++ b/src/Domain/Insights/ForbiddenNormalClasses.php
@@ -25,6 +25,7 @@ final class ForbiddenNormalClasses extends Insight implements HasDetails
     public function getDetails(): array
     {
         $nonFinalClasses = $this->collector->getConcreteNonFinalClasses();
+        /** @var array<string> $nonFinalClasses */
         $nonFinalClasses = array_flip($this->filterFilesWithoutExcluded(
             array_flip($nonFinalClasses)
         ));

--- a/src/Domain/Insights/ForbiddenNormalClasses.php
+++ b/src/Domain/Insights/ForbiddenNormalClasses.php
@@ -11,7 +11,7 @@ final class ForbiddenNormalClasses extends Insight implements HasDetails
 {
     public function hasIssue(): bool
     {
-        return count($this->getDetails()) > 0;
+        return $this->getDetails() !== [];
     }
 
     public function getTitle(): string

--- a/src/Domain/Insights/ForbiddenTraits.php
+++ b/src/Domain/Insights/ForbiddenTraits.php
@@ -14,7 +14,7 @@ final class ForbiddenTraits extends Insight implements HasDetails
 {
     public function hasIssue(): bool
     {
-        return count($this->getDetails()) > 0;
+        return $this->getDetails() !== [];
     }
 
     public function getTitle(): string

--- a/src/Domain/Insights/Insight.php
+++ b/src/Domain/Insights/Insight.php
@@ -36,7 +36,7 @@ abstract class Insight implements InsightContract
         /** @var array<string> $exclude */
         $exclude = $config['exclude'] ?? [];
 
-        if (count($exclude) > 0) {
+        if ($exclude !== []) {
             $this->excludedFiles = Files::find(
                 (string) (getcwd() ?? $collector->getCommonPath()),
                 $exclude

--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -39,7 +39,7 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
         $this->sniff = $sniff;
         $this->excludedFiles = [];
 
-        if (count($this->getIgnoredFilesPath()) > 0) {
+        if ($this->getIgnoredFilesPath() !== []) {
             $this->excludedFiles = Files::find($dir, $this->getIgnoredFilesPath());
         }
     }
@@ -83,7 +83,7 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
      */
     public function hasIssue(): bool
     {
-        return count($this->errors) !== 0;
+        return $this->errors !== [];
     }
 
     /**

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -28,7 +28,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
     public function hasIssue(): bool
     {
-        return \count($this->details) > 0;
+        return $this->details !== [];
     }
 
     public function getDetails(): array

--- a/src/Domain/Metrics/Architecture/Classes.php
+++ b/src/Domain/Metrics/Architecture/Classes.php
@@ -41,6 +41,6 @@ final class Classes implements HasValue, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return count($collector->getFiles()) > 0 ? $collector->getClasses() / count($collector->getFiles()) * 100 : 0;
+        return $collector->getFiles() !== [] ? $collector->getClasses() / count($collector->getFiles()) * 100 : 0;
     }
 }

--- a/src/Domain/Metrics/Architecture/Globally.php
+++ b/src/Domain/Metrics/Architecture/Globally.php
@@ -16,6 +16,6 @@ final class Globally implements HasPercentage
             - $collector->getInterfaces()
             - count($collector->getTraits());
 
-        return count($collector->getFiles()) > 0 ? $value / count($collector->getFiles()) * 100 : 0;
+        return $collector->getFiles() !== [] ? $value / count($collector->getFiles()) * 100 : 0;
     }
 }

--- a/src/Domain/Metrics/Architecture/Interfaces.php
+++ b/src/Domain/Metrics/Architecture/Interfaces.php
@@ -19,7 +19,7 @@ final class Interfaces implements HasValue, HasPercentage, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return count($collector->getFiles()) > 0
+        return $collector->getFiles() !== []
             ? $collector->getInterfaces() / count($collector->getFiles()) * 100
             : 0;
     }

--- a/src/Domain/Metrics/Architecture/Traits.php
+++ b/src/Domain/Metrics/Architecture/Traits.php
@@ -20,7 +20,7 @@ final class Traits implements HasValue, HasInsights
 
     public function getPercentage(Collector $collector): float
     {
-        return count($collector->getFiles()) > 0
+        return $collector->getFiles() !== []
             ? count($collector->getTraits()) / count($collector->getFiles()) * 100
             : 0;
     }

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -149,7 +149,7 @@ final class Runner
             $runningProcesses[] = $process;
         }
 
-        while (\count($runningProcesses) > 0) {
+        while ($runningProcesses !== []) {
             foreach ($runningProcesses as $i => $runningProcess) {
                 if (! $runningProcess->isRunning()) {
                     $progressBar->advance(\count($filesByThread[$i]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| QA      | yes


This PR apply to latest rector and update to use latest rector compatible config:

- bootstrapping files via Option::BOOTSTRAP_FILES config.
- remove deprecated cache Option:: ENABLE_CACHE config as cached by default.
- skip `RemoveUnusedPromotedPropertyRector` as phpinsights still support php 7.4.
- run the rector.