### PR TITLE
(fix): add "github-action" as a format option

### DIFF
--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -55,7 +55,7 @@ final class AnalyseDefinition extends BaseDefinition
                 'format',
                 null,
                 InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
-                'Format to output the result in [console, json, checkstyle, codeclimate]',
+                'Format to output the result in [console, json, checkstyle, codeclimate, github-action]',
                 ['console']
             ),
             new InputOption(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | none

adding missing `github-action` format to `help` message.

it is described in the documentation for CI:
https://phpinsights.com/continuous-integration.html#github-action

but is not present on the help output, so it can lead to some people
making some awkward `jq` transformations on theirs workflows.

