### PR TITLE
Fix missing fields for CodeClimate formatter

### DIFF
--- a/src/Application/Console/Formatters/CodeClimate.php
+++ b/src/Application/Console/Formatters/CodeClimate.php
@@ -81,7 +81,7 @@ final class CodeClimate implements Formatter
                 /** @var Details $detail */
                 foreach ($details as $detail) {
                     $data[] = [
-                        'checkname' => $insight->getInsightClass(),
+                        'check_name' => $insight->getInsightClass(),
                         'description' => $detail->hasMessage() ? $detail->getMessage() : null,
                         'fingerprint' => md5(
                             implode(
@@ -99,6 +99,7 @@ final class CodeClimate implements Formatter
                             ],
                         ],
                         'category' => $climateCategories[$category],
+                        'severity' => 'minor',
                     ];
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #526

Actually, I was wrong (see #526 ), there is only "severity" field was missing 
![image](https://user-images.githubusercontent.com/16526639/135660084-7ce01ee8-398a-414e-9490-770ad51afdb0.png)
https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#configuring-jobs-using-variables

Works fine on GitLab Community Edition 13.12.0 
