### PR TITLE
Get ready for PHP8.1 and SF6

### DIFF
--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -14,13 +14,10 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 version: ['^4.4', '@stable', '@dev'] # Test current LTS, current release, and future release
-                php: ['7.4', '8.0']
+                php: ['7.4', '8.0', '8.1']
                 composer-version: [v2]
-                exclude:
-                    - version: '^4.4'
-                      php: '8.0'
         env:
-            allow_failure: ${{ matrix.version == '@dev' || matrix.php == '8.0' }}
+            allow_failure: ${{ matrix.version == '@dev' }}
         name: "Symfony skeleton:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
 
         steps:
@@ -58,7 +55,7 @@ jobs:
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Install PHPInsights
               working-directory: ./project
-              run: composer require --dev "nunomaduro/phpinsights:*" -n --ansi
+              run: composer require --dev "nunomaduro/phpinsights:*" -n --ansi --with-all-dependencies
               continue-on-error: true
             - name: Launch PHPInsights
               working-directory: ./project

--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -71,14 +71,14 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                version: ['^7.0', '^8.0']
-                php: ['7.4', '8.0']
+                version: ['^8.0', 'dev-master']
+                php: ['7.4', '8.0', '8.1']
                 composer-version: [v2]
                 exclude:
-                    - version: '^7.0'
-                      php: '8.0'
+                    -   version: 'dev-master'
+                        php: '7.4'
         env:
-            allow_failure: ${{ matrix.php == '8.0' }}
+            allow_failure: ${{ matrix.php == '8.0' || matrix.version == 'dev-master' }}
         name: "Laravel:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
 
         steps:
@@ -120,7 +120,7 @@ jobs:
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Install PHPInsights
               working-directory: ./project
-              run: composer require --dev "nunomaduro/phpinsights:*" -n --ansi
+              run: composer require --dev "nunomaduro/phpinsights:*" -n --ansi --with-all-dependencies
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Artisan publish
               working-directory: ./project

--- a/.github/workflows/standalone.yaml
+++ b/.github/workflows/standalone.yaml
@@ -13,13 +13,14 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                php: ['7.4', '8.0']
+                php: ['7.4', '8.0', '8.1']
                 dependency-version: [prefer-lowest, prefer-stable]
                 composer-version: [v2]
                 exclude:
                     -   dependency-version: prefer-lowest
                         php: '8.0'
-
+                    -   dependency-version: prefer-lowest
+                        php: '8.1'
         name: ${{ matrix.php }} - ${{ matrix.os }} - Composer ${{ matrix.composer-version }} --${{ matrix.dependency-version }}
 
         steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,14 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: ['7.4', '8.0']
+                php: ['7.4', '8.0', '8.1']
                 dependency-version: [prefer-lowest, prefer-stable]
                 composer-version: [ v2 ]
                 exclude:
                     -   dependency-version: prefer-lowest
                         php: '8.0'
-
+                    -   dependency-version: prefer-lowest
+                        php: '8.1'
         name: ${{ matrix.php }} - Composer ${{ matrix.composer-version }} --${{ matrix.dependency-version }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
         "psr/simple-cache": "^1.0",
         "slevomat/coding-standard": "^7.0.8",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/cache": "^4.4|^5.0",
-        "symfony/console": "^4.2|^5.0",
-        "symfony/finder": "^4.2|^5.0",
-        "symfony/http-client": "^4.3|^5.0"
+        "symfony/cache": "^4.4|^5.0|^6.0",
+        "symfony/console": "^4.2|^5.0|^6.0",
+        "symfony/finder": "^4.2|^5.0|^6.0",
+        "symfony/http-client": "^4.3|^5.0|^6.0"
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | N/A

Allow Symfony 6 dependencies

Currently, the `php-cs-fixer` don't allow it yet, but I believe the upgrade will be made soon.

Also add PHP8.1 in workflow to be sure the tool still work on PHP8.1, and guess what ? It works :raised_hands: 


