### PR TITLE
Refs #519 - handle summary option in JsonFormatter

### DIFF
--- a/src/Application/Console/Formatters/Json.php
+++ b/src/Application/Console/Formatters/Json.php
@@ -11,6 +11,7 @@ use NunoMaduro\PhpInsights\Domain\Details;
 use NunoMaduro\PhpInsights\Domain\DetailsComparator;
 use NunoMaduro\PhpInsights\Domain\Insights\Insight;
 use NunoMaduro\PhpInsights\Domain\Insights\InsightCollection;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -19,10 +20,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class Json implements Formatter
 {
     private OutputInterface $output;
+    private bool $summaryOnly = false;
 
-    public function __construct(OutputInterface $output)
+    public function __construct(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
+        if ($input->hasOption('summary')) {
+            $this->summaryOnly = (bool) $input->getOption('summary');
+        }
     }
 
     /**
@@ -47,7 +52,9 @@ final class Json implements Formatter
             ],
         ];
 
-        $data += $this->issues($insightCollection, $metrics);
+        if (! $this->summaryOnly) {
+            $data += $this->issues($insightCollection, $metrics);
+        }
 
         $json = json_encode($data, JSON_THROW_ON_ERROR);
 

--- a/tests/Application/Console/Formatters/JsonTest.php
+++ b/tests/Application/Console/Formatters/JsonTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Console\Formatters;
+
+use NunoMaduro\PhpInsights\Application\Console\Formatters\Json;
+use NunoMaduro\PhpInsights\Domain\Metrics\Style\Style;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+final class JsonTest extends TestCase
+{
+    public function testItHasSectionForMetricsGiven(): void
+    {
+        $collection = $this->runAnalyserOnPreset(
+            'default',
+            [__DIR__ . '/JsonTest.php']
+        );
+        $output = new BufferedOutput();
+        $input = new ArrayInput(['--summary' => false], new InputDefinition([new InputOption('summary')]));
+
+        $console = new Json($input, $output);
+
+        $console->format($collection, [Style::class]);
+
+        $result = json_decode($output->fetch(), true);
+        self::assertArrayHasKey('summary', $result);
+        self::assertArrayHasKey('Style', $result);
+    }
+
+    public function testItHasOnlySummary(): void
+    {
+        $collection = $this->runAnalyserOnPreset(
+            'default',
+            [__DIR__ . '/JsonTest.php']
+        );
+        $output = new BufferedOutput();
+        $input = new ArrayInput(['--summary' => true], new InputDefinition([new InputOption('summary')]));
+
+        $console = new Json($input, $output);
+
+        $console->format($collection, [Style::class]);
+
+        $result = json_decode($output->fetch(), true);
+        self::assertArrayHasKey('summary', $result);
+        self::assertArrayNotHasKey('Style', $result);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #519

As asked in #519, handle summary option also in JsonFormatter
