### PR TITLE
Fix #517 by always loading CodeSniffer tokens

### DIFF
--- a/src/Domain/Kernel.php
+++ b/src/Domain/Kernel.php
@@ -46,6 +46,13 @@ final class Kernel
         if (! defined('PHP_CODESNIFFER_VERBOSITY')) {
             define('PHP_CODESNIFFER_VERBOSITY', 0);
         }
+
+        /**
+         * Require Tokens utils From PHP Codesniffer.
+         */
+        require_once file_exists(__DIR__ . '/../../vendor/squizlabs/php_codesniffer/src/Util/Tokens.php')
+            ? __DIR__ . '/../../vendor/squizlabs/php_codesniffer/src/Util/Tokens.php'
+            : __DIR__ . '/../../../../../vendor/squizlabs/php_codesniffer/src/Util/Tokens.php';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #517

Refs issue #517

When we remove `PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff::class`, the `PHP_CodeSniffer\Util\Tokens` class is not called. Other sniffs may use Tokens defined in this file, without requiring it, and lead to an error. 

Requiring file into Kernel allow to have all theses tokens defined anyway.