### PR TITLE
Fix namespaces in fixtures in ForbiddenSetterMethods folder

### DIFF
--- a/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/AnonymousClassWithSetter.php
+++ b/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/AnonymousClassWithSetter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Domain\Insights\ForbiddenSetterMethods\Fixtures;
+namespace Tests\Domain\Sniffs\ForbiddenSetterMethods\Fixtures;
 
 new class
 {

--- a/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/ClassWithLaravelAttributeSetter.php
+++ b/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/ClassWithLaravelAttributeSetter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Domain\Insights\ForbiddenSetterMethods\Fixtures;
+namespace Tests\Domain\Sniffs\ForbiddenSetterMethods\Fixtures;
 
 class ClassWithLaravelAttributeSetter
 {

--- a/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/ClassWithNoSetter.php
+++ b/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/ClassWithNoSetter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Domain\Insights\ForbiddenSetterMethods\Fixtures;
+namespace Tests\Domain\Sniffs\ForbiddenSetterMethods\Fixtures;
 
 class ClassWithNoSetter
 {

--- a/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/ClassWithSetter.php
+++ b/tests/Domain/Sniffs/ForbiddenSetterMethods/Fixtures/ClassWithSetter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Domain\Insights\ForbiddenSetterMethods\Fixtures;
+namespace Tests\Domain\Sniffs\ForbiddenSetterMethods\Fixtures;
 
 class ClassWithSetter
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | no found

It seems that there is an inaccuracy in the namespaces in fixtures located in the ForbiddenSetterMethods folder.