### PR TITLE
fix(ComposerLoader): use full load to avoid that when using composer/composer ^2.3 a PartialComposer is returned

### DIFF
--- a/src/Domain/ComposerLoader.php
+++ b/src/Domain/ComposerLoader.php
@@ -27,7 +27,7 @@ final class ComposerLoader
 
             $io = new NullIO();
             $composerPath = ComposerFinder::getPath($collector);
-            self::$composer = (new Factory())->createComposer($io, ComposerFinder::getPath($collector), false, null, false);
+            self::$composer = (new Factory())->createComposer($io, ComposerFinder::getPath($collector), false, null, true);
             self::$composer->setLocker(self::getLocker($composerPath, $io));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #565 

This is a simple fix in an attempt to get the package working when minimum-stability is set to "dev" in composer.json and doesnt address input from Jordi Boggiano in https://github.com/nunomaduro/phpinsights/issues/559
