### PR TITLE
bump docker to php 8.0, fixes #556

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-cli-alpine
+FROM php:8.0-cli-alpine
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #556

Bumping to PHP 8.0 fixes the `Syntax error` as mentioned in the issue. The new docker tag has been pushed already. 

I'm going to hold off on multiple docker images/tags for different PHP versions until we see how this fix goes.
