### PR TITLE
Updating Local File Repo to ensure tests are included in checks

### DIFF
--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -15,7 +15,7 @@ use Symfony\Component\Finder\Finder;
  */
 final class LocalFilesRepository implements FilesRepository
 {
-    public const DEFAULT_EXCLUDE = ['vendor', 'tests', 'Tests', 'test', 'Test'];
+    public const DEFAULT_EXCLUDE = ['vendor'];
 
     private Finder $finder;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| Fixed tickets | #553 

The docs state that:

> By default, phpinsights will analyse all your php files in your project directory, except folders bower_components, node_modules and vendor.

For some reason it was also including tests in the code. This behaviour is not what I would expect from the docs, so updating to enable this.
