### PR TITLE
Update config key for ordered class elements fixer

### DIFF
--- a/docs/insights/style.md
+++ b/docs/insights/style.md
@@ -741,7 +741,7 @@ This sniff orders the elements of classes/interfaces/traits.
         'method_protected',
         'method_private',  
     ],
-    'sortAlgorithm' => 'none' // possible values ['none', 'alpha']
+    'sort_algorithm' => 'none' // possible values ['none', 'alpha']
 ]
 ```
 </details>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

- Upon running this fixer and trying to modify the order of class elements the key taken from the docs of `sortAlgorithm` ended up not being correct. The correct key for this fixer is snake cased as `sort_algorithm`. This PR will fix this problem.
