### PR TITLE
Allow psr/simple-cache ^2.0 and ^3.0

### DIFF
--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -16,6 +16,13 @@ jobs:
                 version: ['^4.4', '@stable', '@dev'] # Test current LTS, current release, and future release
                 php: ['7.4', '8.0', '8.1']
                 composer-version: [v2]
+                include:
+                  - version: '^4.4'
+                    psr-simple-cache-version: '^1.0|^2.0'
+                  - version: '@stable'
+                    psr-simple-cache-version: '^1.0|^2.0|^3.0'
+                  - version: '@dev'
+                    psr-simple-cache-version: '^1.0|^2.0|^3.0'
         env:
             allow_failure: ${{ matrix.version == '@dev' }}
         name: "Symfony skeleton:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
@@ -52,6 +59,10 @@ jobs:
               run: |
                   composer config prefer-stable true
                   composer config minimum-stability dev
+              continue-on-error: ${{ env.allow_failure == 'true' }}
+            - name: Require psr/simple-cache
+              working-directory: ./project
+              run: composer require "psr/simple-cache:${{ matrix.psr-simple-cache-version }}"
               continue-on-error: ${{ env.allow_failure == 'true' }}
             - name: Install PHPInsights
               working-directory: ./project

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phploc/phploc": "^5.0|^6.0|^7.0",
         "psr/container": "^1.0|^2.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1.0|^2.0|^3.0",
         "slevomat/coding-standard": "^7.0.8",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #522 #573 

Allows installation of `psr/simple-cache` in versions `^2.0` and `^3.0`
