### PR TITLE
add laravel 9 to GH actions test suite

### DIFF
--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -71,14 +71,18 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                version: ['^8.0', 'dev-master']
+                version: ['^9.0', '^8.0', 'dev-master']
                 php: ['7.4', '8.0', '8.1']
                 composer-version: [v2]
                 exclude:
+                    -   version: '^9.0'
+                        php: '7.4'
                     -   version: 'dev-master'
                         php: '7.4'
+                    -   version: 'dev-master'
+                        php: '8.0'
         env:
-            allow_failure: ${{ matrix.php == '8.0' || matrix.version == 'dev-master' }}
+            allow_failure: ${{ matrix.php == '8.1' || matrix.version == 'dev-master' }}
         name: "Laravel:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
 
         steps:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | na

GH Actions only took into account Laravel 8 and `dev-master`. This PR updates the action to include Laravel 9
