### PR TITLE
Fixes #553 adds dont-exclude-tests option to allow analyse of tests folders

### DIFF
--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -58,6 +58,16 @@ For example:
     ],
 ```
 
+## Enable analyse of test folders
+
+By default, `phpinsights` will exclude test folders from analyse, those folders are any named `tests`, `Tests`, `test` or `Test`.
+
+This behaviour can be disabled in your `phpinsights.php`.
+
+```php
+    'dont_exclude_tests' => true,
+```
+
 ## Add Insights
 
 If you create an Insight, or an Insight is not enabled, you can enable it in the `add` section.

--- a/src/Application/ConfigResolver.php
+++ b/src/Application/ConfigResolver.php
@@ -47,7 +47,7 @@ final class ConfigResolver
     public static function resolve(array $config, InputInterface $input): Configuration
     {
         $paths = PathResolver::resolve($input);
-        $config = self::mergeInputRequirements($config, $input);
+        $config = self::mergeInputConfigs($config, $input);
         $composer = self::getComposer($input, $paths[0]);
 
         /** @var string $preset */
@@ -133,14 +133,18 @@ final class ConfigResolver
     }
 
     /**
-     * Merge requirements config from console input.
+     * Merge config values from console input.
      *
      * @param array<string, string|array> $config
      *
      * @return array<string, string|array>
      */
-    private static function mergeInputRequirements(array $config, InputInterface $input): array
+    private static function mergeInputConfigs(array $config, InputInterface $input): array
     {
+        if ($input->hasOption('dont-exclude-tests') && $input->getOption('dont-exclude-tests')) {
+            $config['dont_exclude_tests'] = true;
+        }
+
         $requirements = Configuration::getAcceptedRequirements();
         foreach ($requirements as $requirement) {
             if ($input->hasParameterOption('--' . $requirement)) {

--- a/src/Application/Console/Definitions/AnalyseDefinition.php
+++ b/src/Application/Console/Definitions/AnalyseDefinition.php
@@ -52,6 +52,12 @@ final class AnalyseDefinition extends BaseDefinition
                 'Disable Security issues check to not throw error if vulnerability is found'
             ),
             new InputOption(
+                'dont-exclude-tests',
+                null,
+                InputOption::VALUE_NONE,
+                'Don\'t exclude tests directories from analyse.'
+            ),
+            new InputOption(
                 'format',
                 null,
                 InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,

--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -254,6 +254,7 @@ final class Configuration
             'preset' => 'default',
             'paths' => [(string) getcwd()],
             'common_path' => '',
+            'dont_exclude_tests' => false,
             'exclude' => [],
             'add' => [],
             'requirements' => [],
@@ -273,6 +274,7 @@ final class Configuration
         $resolver->setAllowedValues('add', $this->validateAddedInsight());
         $resolver->setAllowedValues('config', $this->validateConfigInsights());
         $resolver->setAllowedValues('requirements', $this->validateRequirements());
+        $resolver->setAllowedTypes('dont_exclude_tests', 'bool');
         $resolver->setAllowedTypes('threads', ['null', 'int']);
         $resolver->setAllowedTypes('diff_context', 'int');
         $resolver->setAllowedValues('diff_context', static fn ($value) => $value >= 0);
@@ -301,6 +303,10 @@ final class Configuration
         $this->requirements = $config['requirements'];
         $this->fix = $config['fix'];
         $this->diffContext = $config['diff_context'];
+
+        if (! $config['dont_exclude_tests']) {
+            $this->exclude = array_merge($this->exclude, ['tests/', 'Tests/', 'test/', 'Test/']);
+        }
 
         if (array_key_exists('ide', $config)
             && is_string($config['ide'])

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -9,7 +9,6 @@ use NunoMaduro\PhpInsights\Domain\Container;
 use NunoMaduro\PhpInsights\Domain\Contracts\GlobalInsight;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Details;
-use NunoMaduro\PhpInsights\Infrastructure\Repositories\LocalFilesRepository;
 use PHP_CodeSniffer\Config;
 use Symfony\Component\Process\Process;
 
@@ -97,7 +96,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
         return array_map(
             static fn (string $file): string => '--exclude ' . escapeshellarg($file),
-            array_merge($rootExcludes, $localExcludes, LocalFilesRepository::DEFAULT_EXCLUDE)
+            array_merge($rootExcludes, $localExcludes)
         );
     }
 

--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -15,8 +15,6 @@ use Symfony\Component\Finder\Finder;
  */
 final class LocalFilesRepository implements FilesRepository
 {
-    public const DEFAULT_EXCLUDE = ['vendor', 'tests', 'Tests', 'test', 'Test'];
-
     private Finder $finder;
 
     /**
@@ -85,17 +83,10 @@ final class LocalFilesRepository implements FilesRepository
         $this->finder = Finder::create()
             ->files()
             ->name(['*.php'])
-            ->exclude(self::DEFAULT_EXCLUDE)
             ->notName(['*.blade.php'])
             ->ignoreUnreadableDirs()
             ->in($this->directoryList ?? [])
             ->notPath($exclude);
-
-        foreach ($exclude as $value) {
-            if (substr($value, -4) === '.php') {
-                $this->finder->notName($value);
-            }
-        }
 
         return $this->getFilesList();
     }

--- a/stubs/config.php
+++ b/stubs/config.php
@@ -50,6 +50,8 @@ return [
     |
     */
 
+    'dont_exclude_tests' => false,
+
     'exclude' => [
         //  'path/to/directory-or-file'
     ],

--- a/tests/Application/ConfigResolverTest.php
+++ b/tests/Application/ConfigResolverTest.php
@@ -229,6 +229,23 @@ final class ConfigResolverTest extends TestCase
         self::assertEquals(1, $config->getMinComplexity());
     }
 
+    public function testMergeInputDontExcludeTests(): void
+    {
+        $input = new ArrayInput(
+            [
+                '--dont-exclude-tests' => 1,
+            ],
+            new InputDefinition([
+                new InputArgument('paths'),
+                new InputOption('dont-exclude-tests', null, InputOption::VALUE_NONE),
+            ])
+        );
+
+        $config = ConfigResolver::resolve([], $input);
+
+        self::assertNotContains(['tests/'], $config->getExcludes());
+    }
+
     public function testOverridePresetByConfig(): void
     {
         $preset = LaravelPreset::get(new Composer([]));

--- a/tests/Domain/ConfigurationTest.php
+++ b/tests/Domain/ConfigurationTest.php
@@ -20,7 +20,7 @@ final class ConfigurationTest extends TestCase
         self::assertEquals([getcwd()], $configuration->getPaths());
         self::assertEquals('default', $configuration->getPreset());
         self::assertEquals([], $configuration->getAdd());
-        self::assertEquals([], $configuration->getExcludes());
+        self::assertEquals(['tests/', 'Tests/', 'test/', 'Test/'], $configuration->getExcludes());
         self::assertEquals([], $configuration->getConfig());
         self::assertEquals([], $configuration->getRemoves());
     }
@@ -122,6 +122,35 @@ final class ConfigurationTest extends TestCase
         $this->expectException(InvalidConfiguration::class);
         $this->expectExceptionMessage('The option "threads" with value');
         new Configuration(['threads' => $invalid]);
+    }
+
+    public function testDontExcludeTests(): void
+    {
+        $configuration = new Configuration(['dont_exclude_tests' => true, 'exclude' => ['some/path']]);
+
+        self::assertSame(['some/path'], $configuration->getExcludes());
+    }
+
+    public function testDontExcludeTestsWithDefaultValue(): void
+    {
+        $configuration = new Configuration(['exclude' => ['some/path']]);
+
+        self::assertSame(['some/path', 'tests/', 'Tests/', 'test/', 'Test/'], $configuration->getExcludes());
+    }
+
+    public function testDontExcludeTestsWithInvalidValue(): void
+    {
+        $this->expectException(InvalidConfiguration::class);
+        $this->expectExceptionMessage('The option "dont_exclude_tests" with value');
+
+        new Configuration(['dont_exclude_tests' => 'aaa']);
+    }
+
+    public function testDefineDontExcludeTests(): void
+    {
+        $configuration = new Configuration(['dont_exclude_tests' => false, 'exclude' => ['some/path']]);
+
+        self::assertSame(['some/path', 'tests/', 'Tests/', 'test/', 'Test/'], $configuration->getExcludes());
     }
 
     /**


### PR DESCRIPTION
Added dont_exclude_tests config
- Added config option "dont_exclude_tests"
- Added cli option "--dont-exclude-tests"
Small refactor of LocalFilesRepository
- Removed hardcoded list of files for exclusion
- Removed explicit exclussion of files by name, are already excluded by path
Added docs & updated tests

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #553 
