### PR TITLE
Fixing "LogicException Unable to find data for ..." by adding required dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "friendsofphp/php-cs-fixer": "^3.0.0",
         "justinrainbow/json-schema": "^5.1",
         "league/container": "^3.2|^4.2",
+        "php-cs-fixer/diff": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phploc/phploc": "^5.0|^6.0|^7.0",
         "psr/container": "^1.0|^2.0",
@@ -35,7 +36,8 @@
         "symfony/cache": "^4.4|^5.0|^6.0",
         "symfony/console": "^4.2|^5.0|^6.0",
         "symfony/finder": "^4.2|^5.0|^6.0",
-        "symfony/http-client": "^4.3|^5.0|^6.0"
+        "symfony/http-client": "^4.3|^5.0|^6.0",
+        "symfony/process": "^5.4"
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/console": "^4.2|^5.0|^6.0",
         "symfony/finder": "^4.2|^5.0|^6.0",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/process": "^5.4"
+        "symfony/process": "^5.4|^6.0"
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets |

Fixing "LogicException Unable to find data for ..." last days error. It happens, because transitive dependency php-cs-fixer/diff was removed. It was used in phpinsights, but not stated in composer.json.
All fresh installation, where `php-cs-fixer/diff` required directly or where older version of phpcs is fixed, don't work anymore.
https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/b3cc7ef69fd67b9b2c156329a3e820667a0c800a#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L23-R23