### PR TITLE
Resolves #37 - Changed the foreground color of the box labels to white (Windows issue)

### DIFF
--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -51,25 +51,25 @@ final class Console implements Formatter
 
     private const QUALITY = <<<EOD
     <%quality_color%>%block_size%</>
-    <fg=black;options=bold;%quality_color%>  %quality%  </>
+    <fg=white;options=bold;%quality_color%>  %quality%  </>
     <%quality_color%>%block_size%</>
     EOD;
 
     private const COMPLEXITY = <<<EOD
     <%complexity_color%>%block_size%</>
-    <fg=black;options=bold;%complexity_color%>  %complexity%  </>
+    <fg=white;options=bold;%complexity_color%>  %complexity%  </>
     <%complexity_color%>%block_size%</>
     EOD;
 
     private const STRUCTURE = <<<EOD
     <%structure_color%>%block_size%</>
-    <fg=black;options=bold;%structure_color%>  %structure%  </>
+    <fg=white;options=bold;%structure_color%>  %structure%  </>
     <%structure_color%>%block_size%</>
     EOD;
 
     private const STYLE = <<<EOD
     <%style_color%>%block_size%</>
-    <fg=black;options=bold;%style_color%>  %style%  </>
+    <fg=white;options=bold;%style_color%>  %style%  </>
     <%style_color%>%block_size%</>
     EOD;
 


### PR DESCRIPTION
Changed the foreground color of the box labels for Code, Complexity, Achitecture, and Style from black to white because for some reason on Windows (10) systems black as foreground color doesn't seem to work (see #37).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #37

On Windows (10), the "black" foreground color of the box labels isn't shown as black, but as some kind of medium gray that is almost invisible on a green background and isn't readable on yellow and possibly most other background colors. Changing the foreground color for the box labels to white instead leads to easily readable labels.
