### PR TITLE
Fixes typos in stub files.

### DIFF
--- a/stubs/config.php
+++ b/stubs/config.php
@@ -96,7 +96,7 @@ return [
     |
     | Here you may adjust how many threads (core) PHPInsights can use to perform
     | the analyse. This is optional, don't provide it and the tool will guess
-    | the max core number available. This accept null value or integer > 0.
+    | the max core number available. It accepts null value or integer > 0.
     |
     */
 

--- a/stubs/drupal.php
+++ b/stubs/drupal.php
@@ -96,7 +96,7 @@ return [
     |
     | Here you may adjust how many threads (core) PHPInsights can use to perform
     | the analyse. This is optional, don't provide it and the tool will guess
-    | the max core number available. This accept null value or integer > 0.
+    | the max core number available. It accepts null value or integer > 0.
     |
     */
 

--- a/stubs/laravel.php
+++ b/stubs/laravel.php
@@ -119,7 +119,7 @@ return [
     |
     | Here you may adjust how many threads (core) PHPInsights can use to perform
     | the analyse. This is optional, don't provide it and the tool will guess
-    | the max core number available. This accept null value or integer > 0.
+    | the max core number available. It accepts null value or integer > 0.
     |
     */
 

--- a/stubs/magento2.php
+++ b/stubs/magento2.php
@@ -96,7 +96,7 @@ return [
     |
     | Here you may adjust how many threads (core) PHPInsights can use to perform
     | the analyse. This is optional, don't provide it and the tool will guess
-    | the max core number available. This accept null value or integer > 0.
+    | the max core number available. It accepts null value or integer > 0.
     |
     */
 

--- a/stubs/symfony.php
+++ b/stubs/symfony.php
@@ -96,7 +96,7 @@ return [
     |
     | Here you may adjust how many threads (core) PHPInsights can use to perform
     | the analyse. This is optional, don't provide it and the tool will guess
-    | the max core number available. This accept null value or integer > 0.
+    | the max core number available. It accepts null value or integer > 0.
     |
     */
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | none

I just fixed a minor typo in the stub files. I also replaced "This" with "It" so that each line is exactly 3 chars less than the previous one.
