### PR TITLE
docs: fixed typo

### DIFF
--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -160,7 +160,7 @@ For example, to remove "Unused Parameters" Insight only for some file:
 
 ```php
     'configure' => [
-        \PhpCsFixer\Fixer\Basic\BraceFixer::class => [
+        \PhpCsFixer\Fixer\Basic\BracesFixer::class => [
             'indent' => '  ',
 		],
     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | none

There was a typo in the class name, which has been corrected.

