### PR TITLE
chore: deprecated in strings for PHP8.2

### DIFF
--- a/src/Application/Console/Formatters/Console.php
+++ b/src/Application/Console/Formatters/Console.php
@@ -197,7 +197,7 @@ final class Console implements Formatter
                 if ($insight->getTotalFix() === 0) {
                     continue;
                 }
-                $fix = "<fg=green>• [${category}] </><bold>{$insight->getTitle()}</bold>:";
+                $fix = "<fg=green>• [{$category}] </><bold>{$insight->getTitle()}</bold>:";
 
                 $details = $insight->getFixPerFile();
                 /** @var Details $detail */
@@ -380,7 +380,7 @@ final class Console implements Formatter
 
                 $previousCategory = $category;
 
-                $issue = "\n<fg=red>•</> [${category}] <bold>{$insight->getTitle()}</bold>";
+                $issue = "\n<fg=red>•</> [{$category}] <bold>{$insight->getTitle()}</bold>";
 
                 if (! $insight instanceof HasDetails && ! $this->style->getOutput()->isVerbose()) {
                     $this->style->writeln($issue);
@@ -419,7 +419,7 @@ final class Console implements Formatter
                         $detailString .= ($detailString !== '' ? ': ' : '') . $this->parseDetailMessage($detail);
                     }
 
-                    $issue .= "\n  ${detailString}";
+                    $issue .= "\n  {$detailString}";
                 }
 
                 if (! $this->style->getOutput()->isVerbose() && $totalDetails > 3) {

--- a/src/Domain/Insights/CyclomaticComplexityIsHigh.php
+++ b/src/Domain/Insights/CyclomaticComplexityIsHigh.php
@@ -51,7 +51,7 @@ final class CyclomaticComplexityIsHigh extends Insight implements HasDetails, Gl
 
         $this->details = array_map(static fn ($class, $complexity): Details => Details::make()
             ->setFile($class)
-            ->setMessage("${complexity} cyclomatic complexity"), array_keys($classesComplexity), $classesComplexity);
+            ->setMessage("{$complexity} cyclomatic complexity"), array_keys($classesComplexity), $classesComplexity);
     }
 
     private function getMaxComplexity(): int

--- a/src/Domain/Insights/ForbiddenGlobals.php
+++ b/src/Domain/Insights/ForbiddenGlobals.php
@@ -36,7 +36,7 @@ final class ForbiddenGlobals extends Insight implements HasDetails
             }
 
             $details[] = Details::make()->setFile($file)->setMessage(
-                "Usage of ${global} found; Usage of GLOBALS are discouraged consider not relying on global scope"
+                "Usage of {$global} found; Usage of GLOBALS are discouraged consider not relying on global scope"
             );
         }
 

--- a/src/Domain/Insights/ForbiddenSecurityIssues.php
+++ b/src/Domain/Insights/ForbiddenSecurityIssues.php
@@ -146,7 +146,7 @@ final class ForbiddenSecurityIssues extends Insight implements HasDetails, Globa
                 continue;
             }
             self::$details[] = Details::make()->setMessage(
-                "${packageName}@{$version} {$issue['title']} - {$issue['link']}"
+                "{$packageName}@{$version} {$issue['title']} - {$issue['link']}"
             );
         }
     }

--- a/src/Domain/Results.php
+++ b/src/Domain/Results.php
@@ -170,6 +170,6 @@ final class Results
             }
         }
 
-        throw new InsightClassNotFound("${insightClass} not found in ${category}");
+        throw new InsightClassNotFound("{$insightClass} not found in {$category}");
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #615

Fix the warning `Deprecated: Using ${var} in strings is deprecated, use {$var} instead` when using PHP 8.2

