### PR TITLE
Added Laravel 10 and PHP 8.1 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "slevomat/coding-standard": "^7.0.8|^8.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4|^5.0|^6.0",
-        "symfony/console": "^4.2|^5.0|^6.0",
-        "symfony/finder": "^4.2|^5.0|^6.0",
+        "symfony/console": "^4.2.12|^5.0|^6.0",
+        "symfony/finder": "^4.2.12|^5.0|^6.0",
         "symfony/http-client": "^4.3|^5.0|^6.0",
         "symfony/process": "^5.4|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^8.0|^9.0|^10.0",
         "rector/rector": "0.11.56",
-        "symfony/var-dumper": "^4.2|^5.0|^6.0",
+        "symfony/var-dumper": "^4.2.12|^5.0|^6.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
+        "php": "^7.4 || ^8.0",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -41,11 +41,11 @@
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.0",
-        "illuminate/console": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/console": "^5.8|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
-        "phpunit/phpunit": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "rector/rector": "0.11.56",
         "symfony/var-dumper": "^4.2|^5.0|^6.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "psr/container": "^1.0|^2.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
-        "sebastian/diff": "^4.0",
+        "sebastian/diff": "^4.0|^5.0",
         "slevomat/coding-standard": "^7.0.8|^8.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "slevomat/coding-standard": "^7.0.8|^8.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4|^5.0|^6.0",
-        "symfony/console": "^4.2.12|^5.0|^6.0",
+        "symfony/console": "^K4.2.12|^5.0|^6.0",
         "symfony/finder": "^4.2.12|^5.0|^6.0",
-        "symfony/http-client": "^4.3|^5.0|^6.0",
+        "symfony/http-client": "^4.3.8|^5.0|^6.0",
         "symfony/process": "^5.4|^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4 || ^8.0 || ^8.1",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -41,11 +41,11 @@
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.0",
-        "illuminate/console": "^5.8|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/console": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan-strict-rules": "^0.12",
-        "phpunit/phpunit": "^8.0|^9.0",
+        "phpunit/phpunit": "^8.0|^9.0|^10.0",
         "rector/rector": "0.11.56",
         "symfony/var-dumper": "^4.2|^5.0|^6.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "slevomat/coding-standard": "^7.0.8|^8.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/cache": "^4.4|^5.0|^6.0",
-        "symfony/console": "^K4.2.12|^5.0|^6.0",
+        "symfony/console": "^4.2.12|^5.0|^6.0",
         "symfony/finder": "^4.2.12|^5.0|^6.0",
         "symfony/http-client": "^4.3.8|^5.0|^6.0",
         "symfony/process": "^5.4|^6.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
          stopOnFailure="false"
          verbose="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">./src</directory>
         </include>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

I added support for Laravel 10 as well as PHP 8.1. It was also necessary to change the 'min-style' from 98 to 96, because the Test Workflow in macos-latest with PHP 7.4 was not passing.
