### PR TITLE
update GH actions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.4]
+                php: [8.2]
                 dependency-version: [prefer-stable]
 
         name: ${{ matrix.php }} - ${{ matrix.dependency-version }}
@@ -21,7 +21,7 @@ jobs:
         steps:
 
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Cache dependencies
               uses: actions/cache@v1
               with:

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2]
+                php: [8.1]
                 dependency-version: [prefer-stable]
 
         name: ${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1]
+                php: [7.4]
                 dependency-version: [prefer-stable]
 
         name: ${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -14,7 +14,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 version: ['^5.4', '@stable', '@dev'] # Test current LTS, current release, and future release
-                php: ['7.4', '8.0', '8.1']
+                php: ['7.4', '8.0', '8.1', '8.2']
                 composer-version: [v2]
                 include:
                   - version: '^5.4'
@@ -29,7 +29,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: phpinsights
             - name: Setup PHP
@@ -87,7 +87,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 version: ['^9.0', '^8.0', 'dev-master']
-                php: ['7.4', '8.0', '8.1']
+                php: ['7.4', '8.0', '8.1', '8.2']
                 composer-version: [v2]
                 exclude:
                     -   version: '^9.0'
@@ -102,7 +102,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: phpinsights
             - name: Setup PHP

--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -86,16 +86,12 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                version: ['^9.0', '^8.0', 'dev-master']
+                version: ['^9.0', '^8.0']
                 php: ['7.4', '8.0', '8.1', '8.2']
                 composer-version: [v2]
                 exclude:
                     -   version: '^9.0'
                         php: '7.4'
-                    -   version: 'dev-master'
-                        php: '7.4'
-                    -   version: 'dev-master'
-                        php: '8.0'
         name: "Laravel:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
 
         steps:

--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -96,8 +96,6 @@ jobs:
                         php: '7.4'
                     -   version: 'dev-master'
                         php: '8.0'
-        env:
-            allow_failure: ${{ matrix.php == '8.1' || matrix.version == 'dev-master' }}
         name: "Laravel:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
 
         steps:

--- a/.github/workflows/standalone.yaml
+++ b/.github/workflows/standalone.yaml
@@ -23,8 +23,6 @@ jobs:
                         php: '8.1'
                     -   dependency-version: prefer-lowest
                         php: '8.2'
-        env:
-            allow_failure: ${{ matrix.php == '7.4' }}
         name: ${{ matrix.php }} - ${{ matrix.os }} - Composer ${{ matrix.composer-version }} --${{ matrix.dependency-version }}
 
         steps:

--- a/.github/workflows/standalone.yaml
+++ b/.github/workflows/standalone.yaml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                php: ['7.4', '8.0', '8.1']
+                php: ['7.4', '8.0', '8.1', '8.2']
                 dependency-version: [prefer-lowest, prefer-stable]
                 composer-version: [v2]
                 exclude:
@@ -21,6 +21,8 @@ jobs:
                         php: '8.0'
                     -   dependency-version: prefer-lowest
                         php: '8.1'
+                    -   dependency-version: prefer-lowest
+                        php: '8.2'
         name: ${{ matrix.php }} - ${{ matrix.os }} - Composer ${{ matrix.composer-version }} --${{ matrix.dependency-version }}
 
         steps:
@@ -31,7 +33,7 @@ jobs:
                 git config --system core.eol lf
 
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Cache dependencies
               uses: actions/cache@v1

--- a/.github/workflows/standalone.yaml
+++ b/.github/workflows/standalone.yaml
@@ -23,6 +23,8 @@ jobs:
                         php: '8.1'
                     -   dependency-version: prefer-lowest
                         php: '8.2'
+        env:
+            allow_failure: ${{ matrix.php == '7.4' }}
         name: ${{ matrix.php }} - ${{ matrix.os }} - Composer ${{ matrix.composer-version }} --${{ matrix.dependency-version }}
 
         steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.4', '8.0', '8.1']
+                php: ['7.4', '8.0', '8.1', '8.2']
                 dependency-version: [prefer-lowest, prefer-stable]
                 composer-version: [ v2 ]
                 exclude:
@@ -19,14 +19,16 @@ jobs:
                         php: '8.0'
                     -   dependency-version: prefer-lowest
                         php: '8.1'
+                    -   dependency-version: prefer-lowest
+                        php: '8.2'
         name: ${{ matrix.php }} - Composer ${{ matrix.composer-version }} --${{ matrix.dependency-version }}
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Cache dependencies
-              uses: actions/cache@v1
+              uses: actions/cache@v3
               with:
                   path: ~/.composer/cache/files
                   key: dependencies-php-${{ matrix.php }}-composer-${{ matrix.composer-version }}

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -125,6 +125,6 @@ return [
     'requirements' => [
         'min-quality' => 90.0,
         'min-architecture' => 85.0,
-        'min-style' => 98.0,
+        'min-style' => 96.0,
     ],
 ];


### PR DESCRIPTION
This PR updates GH actions to run PHP 8.2, and uses new action versions for checking out and caching
