### PR TITLE
fix 8.2 deprecated notice

### DIFF
--- a/src/Domain/InsightLoader/SniffLoader.php
+++ b/src/Domain/InsightLoader/SniffLoader.php
@@ -29,7 +29,7 @@ final class SniffLoader implements InsightLoader
         $sniff = new $insightClass();
 
         foreach ($config as $property => $value) {
-            $sniff->{$property} = $value;
+            $sniff->$property = $value;
         }
 
         return new SniffDecorator($sniff, $dir);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

fix:
```bash
composer insights
> vendor/bin/phpinsights analyse -c=./insights.php --composer=./composer.json
PHP Deprecated:  Creation of dynamic property SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff::$newlinesCountBetweenOpenTagAndDeclare is deprecated in /Users/wenbo/MyCode/Oneself/composer-packages/phpinsights/src/Domain/InsightLoader/SniffLoader.php on line 32

Deprecated: Creation of dynamic property SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff::$newlinesCountBetweenOpenTagAndDeclare is deprecated in /Users/wenbo/MyCode/Oneself/composer-packages/phpinsights/src/Domain/InsightLoader/SniffLoader.php on line 32
```