### PR TITLE
Prevent the runner to swallow its threads error

### DIFF
--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -157,7 +157,7 @@ final class Runner
                     continue;
                 }
 
-                if (!$runningProcess->isSuccessful()) {
+                if (! $runningProcess->isSuccessful()) {
                     throw new ProcessFailedException($runningProcess);
                 }
 

--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -13,6 +13,7 @@ use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 /**
@@ -151,11 +152,17 @@ final class Runner
 
         while ($runningProcesses !== []) {
             foreach ($runningProcesses as $i => $runningProcess) {
-                if (! $runningProcess->isRunning()) {
-                    $progressBar->advance(\count($filesByThread[$i]));
-                    unset($runningProcesses[$i]);
+                if ($runningProcess->isRunning()) {
+                    usleep(1000);
+                    continue;
                 }
-                usleep(1000);
+
+                if (!$runningProcess->isSuccessful()) {
+                    throw new ProcessFailedException($runningProcess);
+                }
+
+                $progressBar->advance(\count($filesByThread[$i]));
+                unset($runningProcesses[$i]);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #609

This should fix #609.
Maybe not directly but it should make the initial error bubble up allowing the user to fix it or report it properly instead of having an "Unable to find data for" error.

For example:
```

    0/2205 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%

In Runner.php line 163:

  The command "'/opt/homebrew/Cellar/php@8.1/8.1.17/bin/php' '[...]/vendor/bin/phpinsights' 'internal:processors' 'thread-1-fd43f7fb701672bfec0768e9b3d9828c'" failed.

  Exit Code: 255(Unknown error)

  Working directory: [...]

  Output:
  ================

  Fatal error: Allowed memory size of 33554432 bytes exhausted (tried to allocate 135168 bytes) in [...]/vendor-bin/phpinsights/vendor/squizlabs/php_codesniffer/src/Tokenizers/PHP.php on line 2329


  Error Output:
  ================
  PHP Fatal error:  Allowed memory size of 33554432 bytes exhausted (tried to allocate 135168 bytes) in [...]/vendor-bin/phpinsights/vendor/squizlabs/php_codesniffer/src/Tokenizers/PHP.php on line 2329


analyse [-c|--config-path [CONFIG-PATH]] [-s|--summary] [--min-quality [MIN-QUALITY]] [--min-complexity [MIN-COMPLEXITY]] [--min-architecture [MIN-ARCHITECTURE]] [--min-style [MIN-STYLE]] [--disable-security-check] [--format FORMAT] [--composer [COMPOSER]] [--fix] [--flush-cache] [--] [<paths>...]

make: *** [phpinsights] Error 1
```