### PR TITLE
fix readonly final class architecture side effect issue PHP8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .idea/*
 .env
 .phpunit.result.cache
+.phpunit.cache/
 /composer.lock
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "sebastian/diff": "^4.0|^5.0",
         "slevomat/coding-standard": "^7.0.8|^8.0",
-        "squizlabs/php_codesniffer": "^3.5",
+        "squizlabs/php_codesniffer": "^3.7",
         "symfony/cache": "^4.4|^5.0|^6.0",
         "symfony/console": "^4.2.12|^5.0|^6.0",
         "symfony/finder": "^4.2.12|^5.0|^6.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" bootstrap="vendor/squizlabs/php_codesniffer/tests/bootstrap.php" colors="true" failOnRisky="true" failOnWarning="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" bootstrap="vendor/squizlabs/php_codesniffer/tests/bootstrap.php" colors="true" failOnRisky="true" failOnWarning="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Domain/Analyser.php
+++ b/src/Domain/Analyser.php
@@ -177,9 +177,9 @@ final class Analyser
                         $collector->incrementInterfaces();
                     } elseif (isset($tokens[$i - 2]) &&
                         \is_array($tokens[$i - 2])) {
-                        if ($tokens[$i - 2][0] === \T_ABSTRACT) {
+                        if ($tokens[$i - 2][0] === \T_ABSTRACT || $tokens[$i - 2][0] === \T_READONLY && $tokens[$i - 4][0] === \T_ABSTRACT) {
                             $collector->addAbstractClass($filename);
-                        } elseif ($tokens[$i - 2][0] === \T_FINAL || $tokens[$i - 4][0] === \T_FINAL) {
+                        } elseif ($tokens[$i - 2][0] === \T_FINAL || $tokens[$i - 2][0] === \T_READONLY && $tokens[$i - 4][0] === \T_FINAL) {
                             $collector->addConcreteFinalClass($filename);
                         } else {
                             $collector->addConcreteNonFinalClass($filename);

--- a/src/Domain/Analyser.php
+++ b/src/Domain/Analyser.php
@@ -179,7 +179,7 @@ final class Analyser
                         \is_array($tokens[$i - 2])) {
                         if ($tokens[$i - 2][0] === \T_ABSTRACT) {
                             $collector->addAbstractClass($filename);
-                        } elseif ($tokens[$i - 2][0] === \T_FINAL) {
+                        } elseif ($tokens[$i - 2][0] === \T_FINAL || $tokens[$i - 4][0] === \T_FINAL) {
                             $collector->addConcreteFinalClass($filename);
                         } else {
                             $collector->addConcreteNonFinalClass($filename);

--- a/tests/Domain/Insights/Fixtures/ReadonlyClass.php
+++ b/tests/Domain/Insights/Fixtures/ReadonlyClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Domain\Insights\Fixtures;
+
+/**
+ * @see \Tests\Domain\Insights\ReadonlyClassTest
+ */
+readonly class ReadonlyClass {
+    public function __construct(
+        private string $foo,
+        private string $bar,
+    ) {
+    }
+}

--- a/tests/Domain/Insights/ReadonlyClassTest.php
+++ b/tests/Domain/Insights/ReadonlyClassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Insights;
+
+use NunoMaduro\PhpInsights\Application\Console\Formatters\PathShortener;
+use NunoMaduro\PhpInsights\Domain\Analyser;
+use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenNormalClasses;
+use NunoMaduro\PhpInsights\Domain\Metrics\Architecture\Classes;
+use Tests\TestCase;
+
+final class ReadonlyClassTest extends TestCase
+{
+    public function testHasIssue(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            self::markTestSkipped('Readonly classes are only available in PHP 8.2+');
+        }
+
+        $files = [
+            __DIR__ . '/Fixtures/ReadonlyClass.php',
+        ];
+
+        $analyzer = new Analyser();
+        $collector = $analyzer->analyse([__DIR__ . '/Fixtures/'], $files, PathShortener::extractCommonPath($files));
+        $insight = new ForbiddenNormalClasses($collector, []);
+
+        self::assertTrue($insight->hasIssue());
+        self::assertIsArray($insight->getDetails());
+        self::assertNotEmpty($insight->getDetails());
+    }
+
+    public function testSkipFile(): void
+    {
+        $fileLocation = __DIR__ . '/Fixtures/ReadonlyClass.php';
+
+        $collection = $this->runAnalyserOnConfig(
+            [
+                'add' => [
+                    Classes::class => [
+                        ForbiddenNormalClasses::class,
+                    ],
+                ],
+                'config' => [
+                    ForbiddenNormalClasses::class => [
+                        'exclude' => [$fileLocation],
+                    ],
+                ],
+            ],
+            [$fileLocation]
+        );
+
+        $classErrors = 0;
+
+        foreach ($collection->allFrom(new Classes()) as $insight) {
+            if ($insight->hasIssue() && $insight->getInsightClass() === ForbiddenNormalClasses::class) {
+                $classErrors++;
+            }
+        }
+
+        self::assertEquals(0, $classErrors);
+    }
+}

--- a/tests/Domain/Insights/SyntaxCheckTest.php
+++ b/tests/Domain/Insights/SyntaxCheckTest.php
@@ -50,11 +50,9 @@ final class SyntaxCheckTest extends TestCase
 
                 self::assertTrue($insight->hasIssue());
                 if (PHP_MAJOR_VERSION === 7) {
-                    self::assertCount(2, $details);
-                } elseif (PHP_VERSION_ID < 80200) {
-                    self::assertCount(4, $details);
-                } else {
                     self::assertCount(3, $details);
+                } else {
+                    self::assertCount(4, $details);
                 }
 
                 /** @var \NunoMaduro\PhpInsights\Domain\Details $detail */

--- a/tests/Domain/Insights/SyntaxCheckTest.php
+++ b/tests/Domain/Insights/SyntaxCheckTest.php
@@ -49,7 +49,7 @@ final class SyntaxCheckTest extends TestCase
                 usort($details, static fn (Details $a, Details $b): int => $a->getFile() <=> $b->getFile());
 
                 self::assertTrue($insight->hasIssue());
-                if (PHP_MAJOR_VERSION === 7) {
+                if (PHP_MAJOR_VERSION === 7 || PHP_VERSION_ID >= 80200) {
                     self::assertCount(3, $details);
                 } else {
                     self::assertCount(4, $details);

--- a/tests/Domain/Insights/SyntaxCheckTest.php
+++ b/tests/Domain/Insights/SyntaxCheckTest.php
@@ -51,6 +51,8 @@ final class SyntaxCheckTest extends TestCase
                 self::assertTrue($insight->hasIssue());
                 if (PHP_MAJOR_VERSION === 7) {
                     self::assertCount(2, $details);
+                } elseif (PHP_VERSION_ID < 80200) {
+                    self::assertCount(4, $details);
                 } else {
                     self::assertCount(3, $details);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #637 

So this fix the `[Architecture] Normal classes are forbidden. Classes must be final or abstract` error message.

To fix the `[Style] Side effects` this [PR](https://github.com/squizlabs/PHP_CodeSniffer/pull/3728) to PHP_CodeSniffer SideEffectsSniff is currently being made and reviewed following this [issue](https://github.com/squizlabs/PHP_CodeSniffer/issues/3727)

I'm not quite sur about how to create tests for this new behavior as I haven't seen any test for the currently working behavior.
But I'd be happy to be wrong about this statement and to be showed which test I should update !