### PR TITLE
Fix error: The option "preset" with value "wordpress" is invalid

### DIFF
--- a/src/Domain/Configuration.php
+++ b/src/Domain/Configuration.php
@@ -10,6 +10,7 @@ use NunoMaduro\PhpInsights\Application\Adapters\Laravel\Preset as LaravelPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Magento2\Preset as Magento2Preset;
 use NunoMaduro\PhpInsights\Application\Adapters\Symfony\Preset as SymfonyPreset;
 use NunoMaduro\PhpInsights\Application\Adapters\Yii\Preset as YiiPreset;
+use NunoMaduro\PhpInsights\Application\Adapters\WordPress\Preset as WordPressPreset;
 use NunoMaduro\PhpInsights\Application\DefaultPreset;
 use NunoMaduro\PhpInsights\Domain\Contracts\FileLinkFormatter as FileLinkFormatterContract;
 use NunoMaduro\PhpInsights\Domain\Contracts\Metric;
@@ -31,6 +32,7 @@ final class Configuration
         SymfonyPreset::class,
         YiiPreset::class,
         Magento2Preset::class,
+        WordPressPreset::class,
         DefaultPreset::class,
     ];
 


### PR DESCRIPTION
Hello, 

This is fixing an issue where phpinsights can't be run when setting preset as `wordpress` in phpinsights.php config file. WordPress preset was added in #378 

Actual error: 
```
   Invalid configuration 
    • The option "preset" with value "wordpress" is invalid. Accepted values are: "drupal", "laravel", "symfony", "yii", "magento2", "default".
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | 

<!--
- Replace this comment by a description of what your PR is solving.
-->
