### PR TITLE
fix 8.2 add AllowDynamicProperties in ForbiddenSetterSniff class

### DIFF
--- a/src/Domain/Sniffs/ForbiddenSetterSniff.php
+++ b/src/Domain/Sniffs/ForbiddenSetterSniff.php
@@ -10,6 +10,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 /**
  * This sniff disallows setter methods.
  */
+#[\AllowDynamicProperties]
 final class ForbiddenSetterSniff implements Sniff
 {
     private const ERROR_MESSAGE = <<<'EOD'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no

Since 8.2, dynamic properties are deprecated. 

An error message is displayed when I ran phpinsights on my project.

`PHP Deprecated:  Creation of dynamic property NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff::$exclude is deprecated in /Users/enzo/dev/phpinsights/src/Domain/InsightLoader/SniffLoader.php on line 32`

The `SniffLoader` class uses the dynamic properties pattern 
```
   public function load(string $insightClass, string $dir, array $config, Collector $collector): Insight
    {
        /** @var SniffContract $sniff */
        $sniff = new $insightClass();

        foreach ($config as $property => $value) {
            $sniff->{$property} = $value;
        }

        return new SniffDecorator($sniff, $dir);
    }
 ```   
There's multiple solutions to avoid this depreciation, I'm available to discuss it 😁