### PR TITLE
Fix non-existing default property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/container": "^1.0|^2.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "sebastian/diff": "^4.0|^5.0",
-        "slevomat/coding-standard": "^7.0.8|^8.0",
+        "slevomat/coding-standard": "^8.13",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/cache": "^4.4|^5.0|^6.0",
         "symfony/console": "^4.2.12|^5.0|^6.0",

--- a/src/Application/DefaultPreset.php
+++ b/src/Application/DefaultPreset.php
@@ -42,6 +42,7 @@ final class DefaultPreset implements PresetContract
                     'linesCountBetweenDifferentAnnotationsTypes' => 1,
                 ],
                 DeclareStrictTypesSniff::class => [
+                    'newlinesCountBeforeDeclare' => 2,
                     'spacesCountAroundEqualsSign' => 0,
                 ],
                 UnusedUsesSniff::class => [

--- a/src/Application/DefaultPreset.php
+++ b/src/Application/DefaultPreset.php
@@ -42,7 +42,6 @@ final class DefaultPreset implements PresetContract
                     'linesCountBetweenDifferentAnnotationsTypes' => 1,
                 ],
                 DeclareStrictTypesSniff::class => [
-                    'newlinesCountBetweenOpenTagAndDeclare' => 2,
                     'spacesCountAroundEqualsSign' => 0,
                 ],
                 UnusedUsesSniff::class => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | 

Removing the default for a non-existing property newlinesCountBetweenOpenTagAndDeclare in DeclareStrictTypesSniff  (https://github.com/slevomat/coding-standard/blob/master/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php) that gives an deprecation notice in PHP 8.2.
