### PR TITLE
PHP 8.2 fix for dynamic property $exclude

### DIFF
--- a/src/Domain/InsightLoader/SniffLoader.php
+++ b/src/Domain/InsightLoader/SniffLoader.php
@@ -28,10 +28,18 @@ final class SniffLoader implements InsightLoader
         /** @var SniffContract $sniff */
         $sniff = new $insightClass();
 
+        $excludeConfig = [];
+
+        if (isset($config['exclude'])) {
+            /** @var array<string> $excludeConfig */
+            $excludeConfig = $config['exclude'];
+            unset($config['exclude']);
+        }
+
         foreach ($config as $property => $value) {
             $sniff->{$property} = $value;
         }
 
-        return new SniffDecorator($sniff, $dir);
+        return new SniffDecorator($sniff, $dir, $excludeConfig);
     }
 }

--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -34,13 +34,13 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
      */
     private array $excludedFiles;
 
-    public function __construct(Sniff $sniff, string $dir)
+    public function __construct(Sniff $sniff, string $dir, array $exclude)
     {
         $this->sniff = $sniff;
         $this->excludedFiles = [];
 
-        if ($this->getIgnoredFilesPath() !== []) {
-            $this->excludedFiles = Files::find($dir, $this->getIgnoredFilesPath());
+        if ($exclude !== []) {
+            $this->excludedFiles = Files::find($dir, $exclude);
         }
     }
 
@@ -130,15 +130,5 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
             (string) $file->getFileInfo()->getRealPath(),
             $this->excludedFiles
         );
-    }
-
-    /**
-     * Contains the setting for all files which the sniff should ignore.
-     *
-     * @return array<int, string>
-     */
-    private function getIgnoredFilesPath(): array
-    {
-        return $this->sniff->exclude ?? [];
     }
 }

--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -34,6 +34,13 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
      */
     private array $excludedFiles;
 
+    /**
+     * SniffDecorator constructor.
+     * 
+     * @param Sniff         $sniff
+     * @param string        $dir
+     * @param array<string> $exclude
+     */
     public function __construct(Sniff $sniff, string $dir, array $exclude)
     {
         $this->sniff = $sniff;

--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -36,9 +36,7 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
 
     /**
      * SniffDecorator constructor.
-     * 
-     * @param Sniff         $sniff
-     * @param string        $dir
+     *
      * @param array<string> $exclude
      */
     public function __construct(Sniff $sniff, string $dir, array $exclude)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #647

This change is a more generic solution for #647 to solve the dynamic properties deprecation notice in PHP 8.2.
