### PR TITLE
add quotes around binary path

### DIFF
--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
-use Illuminate\Support\Str;
 use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Container;
 use NunoMaduro\PhpInsights\Domain\Contracts\GlobalInsight;
@@ -78,7 +77,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
         return sprintf(
             '%s %s',
-            preg_replace('#\\s+#',  '\\ ', (string) Config::getExecutablePath('php')),
+            preg_replace('#\\s+#', '\\ ', (string) Config::getExecutablePath('php')),
             escapeshellarg($parentPath . '/parallel-lint')
         );
     }

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -78,7 +78,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
         return sprintf(
             '%s %s',
-            (string) preg_replace('#\\s+#',  '\\ ',Config::getExecutablePath('php')),
+            preg_replace('#\\s+#',  '\\ ', (string) Config::getExecutablePath('php')),
             escapeshellarg($parentPath . '/parallel-lint')
         );
     }

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -78,7 +78,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
         return sprintf(
             '%s %s',
-            (string) Str::of(Config::getExecutablePath('php'))->replace(' ', '\ '),
+            (string) preg_replace('#\\s+#',  '\\ ',Config::getExecutablePath('php')),
             escapeshellarg($parentPath . '/parallel-lint')
         );
     }

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -47,7 +47,6 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
             implode(' ', $this->getShellExcludeArgs()),
             $toAnalyse
         );
-
         $process = Process::fromShellCommandline($cmdLine);
 
         if ($toAnalyse === '.' && getcwd() !== rtrim($this->collector->getCommonPath(), DIRECTORY_SEPARATOR)) {

--- a/src/Domain/Insights/SyntaxCheck.php
+++ b/src/Domain/Insights/SyntaxCheck.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
+use Illuminate\Support\Str;
 use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Container;
 use NunoMaduro\PhpInsights\Domain\Contracts\GlobalInsight;
@@ -46,6 +47,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
             implode(' ', $this->getShellExcludeArgs()),
             $toAnalyse
         );
+
         $process = Process::fromShellCommandline($cmdLine);
 
         if ($toAnalyse === '.' && getcwd() !== rtrim($this->collector->getCommonPath(), DIRECTORY_SEPARATOR)) {
@@ -77,7 +79,7 @@ final class SyntaxCheck extends Insight implements HasDetails, GlobalInsight
 
         return sprintf(
             '%s %s',
-            escapeshellcmd((string) Config::getExecutablePath('php')),
+            (string) Str::of(Config::getExecutablePath('php'))->replace(' ', '\ '),
             escapeshellarg($parentPath . '/parallel-lint')
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #644

This PR allows to escape binary path where php binary like this : 
`/Users/<username>/Library/Application Support/Herd/bin/php82`

We have a space between Application and Support and without quotes, Process stop at `/Users/<username>/Library/Application` and can't find php executable
