### PR TITLE
disable default ignore for dot/vcs files for single files

### DIFF
--- a/src/Infrastructure/Repositories/LocalFilesRepository.php
+++ b/src/Infrastructure/Repositories/LocalFilesRepository.php
@@ -108,6 +108,8 @@ final class LocalFilesRepository implements FilesRepository
         $this->finder = Finder::create()
             ->in($this->fileList['dirname'] ?? [])
             ->name($this->fileList['basename'] ?? '')
+            ->ignoreDotFiles(false)
+            ->ignoreVCS(false)
             ->filter(fn (SplFileInfo $file): bool => in_array(
                 $file->getPathname(),
                 $this->fileList['full_path'] ?? '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #662

Disable `symfony/finder` ignore defaults for single files.
