### PR TITLE
Fix incorrect default value for ‘linesCountBeforeDeclare’

### DIFF
--- a/src/Application/DefaultPreset.php
+++ b/src/Application/DefaultPreset.php
@@ -42,7 +42,7 @@ final class DefaultPreset implements PresetContract
                     'linesCountBetweenDifferentAnnotationsTypes' => 1,
                 ],
                 DeclareStrictTypesSniff::class => [
-                    'newlinesCountBeforeDeclare' => 2,
+                    'linesCountBeforeDeclare' => 2,
                     'spacesCountAroundEqualsSign' => 0,
                 ],
                 UnusedUsesSniff::class => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

The option 'newlinesCountBeforeDeclare' hasn't existed since v7.0.0 and causes the warning 'Creation of dynamic property SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff::$newlinesCountBeforeDeclare is deprecated in /vendor/nunomaduro/phpinsights/src/Domain/InsightLoader/SniffLoader.php on line 40'. The correct option is 'linesCountBeforeDeclare', see https://github.com/slevomat/coding-standard/blob/master/doc/type-hints.md#slevomatcodingstandardtypehintsdeclarestricttypes-
