### PR TITLE
use config for calculating complexity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "psr/container": "^1.0|^2.0.2",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
-        "sebastian/diff": "^4.0|^5.0.3",
+        "sebastian/diff": "^4.0|^5.0.3|^6.0",
         "slevomat/coding-standard": "^8.14.1",
         "squizlabs/php_codesniffer": "^3.7.2",
         "symfony/cache": "^5.4|^6.0|^7.0",

--- a/src/Domain/Insights/InsightCollection.php
+++ b/src/Domain/Insights/InsightCollection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\PhpInsights\Domain\Insights;
 
 use NunoMaduro\PhpInsights\Domain\Collector;
+use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Contracts\Metric;
 use NunoMaduro\PhpInsights\Domain\Results;
 
@@ -22,15 +23,18 @@ final class InsightCollection
 
     private ?Results $results = null;
 
+    private Configuration $configuration;
+
     /**
      * Creates a new instance of the Insight Collection.
      *
      * @param  array<string, array<\NunoMaduro\PhpInsights\Domain\Contracts\Insight>>  $insightsPerMetric
      */
-    public function __construct(Collector $collector, array $insightsPerMetric)
+    public function __construct(Collector $collector, array $insightsPerMetric, Configuration $configuration)
     {
         $this->collector = $collector;
         $this->insightsPerMetric = $insightsPerMetric;
+        $this->configuration = $configuration;
     }
 
     public function getCollector(): Collector
@@ -87,7 +91,7 @@ final class InsightCollection
             $perCategory[$category] = [...$perCategory[$category], ...$insights];
         }
 
-        $this->results = new Results($this->collector, $perCategory);
+        $this->results = new Results($this->collector, $perCategory, $this->configuration);
 
         return $this->results;
     }

--- a/src/Domain/Insights/InsightCollectionFactory.php
+++ b/src/Domain/Insights/InsightCollectionFactory.php
@@ -69,7 +69,7 @@ final class InsightCollectionFactory
             );
         }
 
-        return new InsightCollection($collector, $insightsForCollection);
+        return new InsightCollection($collector, $insightsForCollection, $this->config);
     }
 
     /**

--- a/src/Domain/Results.php
+++ b/src/Domain/Results.php
@@ -8,6 +8,7 @@ use NunoMaduro\PhpInsights\Domain\Contracts\Fixable;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Exceptions\InsightClassNotFound;
+use NunoMaduro\PhpInsights\Domain\Insights\CyclomaticComplexityIsHigh;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
 
 /**
@@ -24,15 +25,18 @@ final class Results
      */
     private array $perCategoryInsights;
 
+    private Configuration $configuration;
+
     /**
      * Creates a new instance of results.
      *
      * @param  array<string, array<\NunoMaduro\PhpInsights\Domain\Contracts\Insight>>  $perCategoryInsights
      */
-    public function __construct(Collector $collector, array $perCategoryInsights)
+    public function __construct(Collector $collector, array $perCategoryInsights, Configuration $configuration)
     {
         $this->collector = $collector;
         $this->perCategoryInsights = $perCategoryInsights;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -48,7 +52,8 @@ final class Results
      */
     public function getComplexity(): float
     {
-        $avg = $this->collector->getAverageComplexityPerMethod() - 1.0;
+        $config = $this->configuration->getConfigForInsight(CyclomaticComplexityIsHigh::class);
+        $avg = $this->collector->getAverageComplexityPerMethod() - $config['maxComplexity'] ?? 1.0;
 
         return (float) number_format(
             100.0 - max(min($avg * 100.0 / 3.0, 100.0), 0.0),

--- a/tests/Application/Console/Formatters/ConsoleTest.php
+++ b/tests/Application/Console/Formatters/ConsoleTest.php
@@ -6,6 +6,7 @@ namespace Tests\Application\Console\Formatters;
 
 use NunoMaduro\PhpInsights\Application\Console\Formatters\Console;
 use NunoMaduro\PhpInsights\Domain\Collector;
+use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Contracts\HasDetails;
 use NunoMaduro\PhpInsights\Domain\Contracts\Insight;
 use NunoMaduro\PhpInsights\Domain\Details;
@@ -65,7 +66,8 @@ final class ConsoleTest extends TestCase
 
         $insightCollection = new InsightCollection(
             new Collector([], '.'),
-            [Style::class => [$insight]]
+            [Style::class => [$insight]],
+            new Configuration([])
         );
 
         $output = new BufferedOutput();
@@ -103,7 +105,8 @@ final class ConsoleTest extends TestCase
 
         $insightCollection = new InsightCollection(
             new Collector([], '.'),
-            [Style::class => [$insight]]
+            [Style::class => [$insight]],
+            new Configuration([])
         );
 
         $output = new BufferedOutput();

--- a/tests/Domain/ResultsTest.php
+++ b/tests/Domain/ResultsTest.php
@@ -6,6 +6,7 @@ namespace Tests\Domain;
 
 use NunoMaduro\PhpInsights\Application\Console\Formatters\PathShortener;
 use NunoMaduro\PhpInsights\Domain\Collector;
+use NunoMaduro\PhpInsights\Domain\Configuration;
 use NunoMaduro\PhpInsights\Domain\Insights\ForbiddenSecurityIssues;
 use NunoMaduro\PhpInsights\Domain\Results;
 use PHPUnit\Framework\TestCase;
@@ -32,7 +33,7 @@ final class ResultsTest extends TestCase
     {
         $collector = new Collector([$this->baseFixturePath], $this->commonPath);
 
-        $results = new Results($collector, ['Security' => []]);
+        $results = new Results($collector, ['Security' => []], new Configuration([]));
 
         self::assertEquals(0, $results->getTotalSecurityIssues());
     }
@@ -46,7 +47,7 @@ final class ResultsTest extends TestCase
             'Security' => [new ForbiddenSecurityIssues($collector, [])],
         ];
 
-        $results = new Results($collector, $categories);
+        $results = new Results($collector, $categories, new Configuration([]));
 
         self::assertGreaterThan(0, $results->getTotalSecurityIssues());
     }
@@ -55,7 +56,7 @@ final class ResultsTest extends TestCase
     {
         $collector = new Collector([$this->baseFixturePath], $this->commonPath);
 
-        $result = new Results($collector, self::CATEGORIES);
+        $result = new Results($collector, self::CATEGORIES, new Configuration([]));
 
         self::assertFalse($result->hasInsightInCategory(
             ForbiddenSecurityIssues::class,
@@ -71,7 +72,7 @@ final class ResultsTest extends TestCase
             'Security' => [new ForbiddenSecurityIssues($collector, [])],
         ];
 
-        $result = new Results($collector, $categories);
+        $result = new Results($collector, $categories, new Configuration([]));
 
         self::assertTrue($result->hasInsightInCategory(
             ForbiddenSecurityIssues::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Previously configuration value for max allowed complexity was only used for reporting errors. For calculating complexity percentage 1 was always used as max allowed complexity. As a result when setting this config value to any number higher than 1 and having any class with complexity higher than 1 disallowed to have complexity percentage at level 100%. This PR fixes this - for now config value for max allowed complexity is both used for percentage calculations and for error reporting
