### PR TITLE
Check Cache Only When Not Fixing

### DIFF
--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -187,7 +187,7 @@ final class Runner
     {
         $cacheKey = 'insights.' . $this->cacheKey . '.' . md5($file->getContents());
         // Do not use cache if fix is enabled to force processors to handle it
-        if (! $this->cache->has($cacheKey)) {
+        if ($this->configuration->hasFixEnabled() && ! $this->cache->has($cacheKey)) {
             throw new \LogicException('Unable to find data for ' . $file->getPathname());
         }
 


### PR DESCRIPTION
Addresses nunomaduro/phpinsights#511

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #511

Implements what the above comment says, such that cache is only checked when not fixing (but I guess only analyzing).
This solves an intermittent (yet persistent for some) problem where fixing some files triggers an error and breaks the process.