### PR TITLE
Fixed type error

### DIFF
--- a/src/Domain/Insights/SniffDecorator.php
+++ b/src/Domain/Insights/SniffDecorator.php
@@ -50,7 +50,7 @@ final class SniffDecorator implements Sniff, Insight, DetailsCarrier, Fixable
     }
 
     /**
-     * @return array<string>
+     * @return array<int|string>
      */
     public function register(): array
     {


### PR DESCRIPTION
Fixed type error

Error: Method NunoMaduro\PhpInsights\Domain\Insights\SniffDecorator::register() should return array<string> but returns array<int|string>.

https://github.com/nunomaduro/phpinsights/pull/692/checks