### PR TITLE
Fix DivisionByZeroError when thread count is 0

### DIFF
--- a/src/Domain/Runner.php
+++ b/src/Domain/Runner.php
@@ -57,7 +57,7 @@ final class Runner
 
         $this->configuration = $container->get(Configuration::class);
         $this->cacheKey = $this->configuration->getCacheKey();
-        $this->threads = $this->configuration->getNumberOfThreads();
+        $this->threads = max(1, $this->configuration->getNumberOfThreads());
     }
 
     /**


### PR DESCRIPTION
# Fix: DivisionByZeroError when Thread Count is 0

## Problem
The application was crashing with a `DivisionByZeroError` when the configured number of threads was set to `0`.  
This occurred during the calculation of file batch sizes for parallel processing.

## Root Cause
The `$this->threads` value was being directly taken from configuration without validation.  
When it was `0`, the calculation:

```php
ceil($totalFiles / $this->threads)
```
resulted in division by zero.

Solution

Added validation in the constructor to ensure the thread count is always at least 1:
```php
$this->threads = max(1, $this->configuration->getNumberOfThreads());
```

Impact

Prevents application crashes when thread configuration is set to 0

Ensures reliable parallel processing with a minimum of 1 thread

Maintains backward compatibility with existing configurations

Testing

The fix ensures that even with threads: 0 in configuration, the application will run successfully with a single thread instead of crashing.
```pgsql

👉 Do you want me to also make a **changelog-style version** (like `CHANGELOG.md` format) or keep it as a **detailed fix report**?

```
