### PR TITLE
:memo: Fix documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: docs
 on:
   # trigger deployment on every push to main branch
   push:
-    branches: [main]
+    branches: [master]
   # trigger deployment manually
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <a href="https://packagist.org/packages/nunomaduro/phpinsights"><img src="https://poser.pugx.org/nunomaduro/phpinsights/license.svg" alt="License"></a>
   </p>
   <p align="center">
-    <strong>For full documentation, visit <a href="https://phpinsights.com">phpinsights.com</a></strong>.
+    <strong>For full documentation, visit <a href="https://nunomaduro.github.io/phpinsights/">nunomaduro.github.io/phpinsights/</a></strong>.
   </p>
 </p>
 

--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -75,7 +75,7 @@ After running `vendor/bin/phpinsights` you saw an error:
   src/YourClass.php:19: Unused parameter $thisIsUnusedParameter.
 ```
 
-After verification [in documentation](https://phpinsights.com/insights/code.html#unused-parameter), you know that `\SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff` class is responsible for the `[Code] Unused parameter` error and it contains `private const NAME = 'SlevomatCodingStandard.Functions.UnusedParameter’;`. Let's use it together with the `@phpcsSuppress` annotation:
+After verification [in documentation](https://nunomaduro.github.io/phpinsights/insights/code.html#unused-parameter), you know that `\SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff` class is responsible for the `[Code] Unused parameter` error and it contains `private const NAME = 'SlevomatCodingStandard.Functions.UnusedParameter’;`. Let's use it together with the `@phpcsSuppress` annotation:
 
 ```php
 final class YourClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #709

(Follow-up of #712, related to #701)

1. Update the workflow to the correct default branch `master` instead of `main`
2. Update links to point to github pages

## TODO (by a maintainer, once merged)

### Enable deployment

Once the `docs` workflow ran, there will be a new `gh-pages` branches. Once this branch exists the deployment can be configured as follows in project settings ([documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch)):

<img width="1109" height="612" alt="image" src="https://github.com/user-attachments/assets/a063300c-28bb-4cdc-8bcf-fd379004e729" />

### Update the "About" section

Change the link to https://nunomaduro.github.io/phpinsights/:

<img width="319" height="142" alt="image" src="https://github.com/user-attachments/assets/10ae99b3-9167-4460-92d7-6ca6d8e7ebdf" />
<img width="640" height="226" alt="image" src="https://github.com/user-attachments/assets/385cbf34-01fd-4b76-a083-345d18822d75" />

(Note that we could deploy from an action too, which would remove the need for `gh-pages` branch, but the current development does not permit this, I can change the process if required)