### PR TITLE
Apply Laravel Pint code style formatting to PHP Insight config for Laravel

### DIFF
--- a/stubs/laravel.php
+++ b/stubs/laravel.php
@@ -105,11 +105,11 @@ return [
     */
 
     'requirements' => [
-//        'min-quality' => 0,
-//        'min-complexity' => 0,
-//        'min-architecture' => 0,
-//        'min-style' => 0,
-//        'disable-security-check' => false,
+        // 'min-quality' => 0,
+        // 'min-complexity' => 0,
+        // 'min-architecture' => 0,
+        // 'min-style' => 0,
+        // 'disable-security-check' => false,
     ],
 
     /*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | --

When installing this package into a Laravel project, the published configuration file — `config/insights.php` — contains commented code that does not conform to the default Laravel Pint preset, triggering the [`array_indentation`](https://cs.symfony.com/doc/rules/whitespace/array_indentation.html) rule.

This pull request formats the PHP Insights config file for Laravel to pass the default Pint checks, ensuring the package a seamless welcome in any Laravel project.