### PR TITLE
Add Laravel 13 to frameworks test workflow

### DIFF
--- a/.github/workflows/frameworks.yaml
+++ b/.github/workflows/frameworks.yaml
@@ -87,7 +87,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                version: ['^11.0', '^12.0'] # TODO: add '^13.0' when released
+                version: ['^11.0', '^12.0', '^13.0']
                 php: ['8.3', '8.4', '8.5']
                 composer-version: [v2]
                 include:
@@ -95,6 +95,8 @@ jobs:
                         phpunit: '^11.0'
                     -   version: '^12.0'
                         phpunit: '^11.0'
+                    -   version: '^13.0'
+                        phpunit: '^12.0'
         name: "Laravel:${{ matrix.version }} - PHP${{ matrix.php }} - Composer ${{ matrix.composer-version }}"
 
         steps:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Fulfill the existing `# TODO: add '^13.0' when released` comment by adding Laravel 13 to the frameworks workflow test matrix.