### PR TITLE
Bump version to 2.14.2

### DIFF
--- a/src/Domain/Kernel.php
+++ b/src/Domain/Kernel.php
@@ -16,7 +16,7 @@ final class Kernel
      *
      * @noRector Rector\DeadCode\Rector\ClassConst\RemoveUnusedClassConstantRector
      */
-    public const VERSION = 'v2.12.0';
+    public const VERSION = 'v2.14.2';
 
     /**
      * Bootstraps the usage of the package.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #719

The `--version` command still reported `v2.12.0` since the constant in `Kernel.php` hadn't been bumped since then. Updated it to `v2.14.2` to match the current release.
