### PR TITLE
Add support for sebastian/diff 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "psr/container": "^2.0.2",
         "psr/simple-cache": "^2.0|^3.0",
-        "sebastian/diff": "^6.0.2|^7.0.0",
+        "sebastian/diff": "^6.0.2|^7.0.0|^9.0",
         "slevomat/coding-standard": "^8.22.1",
         "squizlabs/php_codesniffer": "^3.13.5",
         "symfony/cache": "^7.4.5|^8.0.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #739

Pest 5 requires PHPUnit 13, which in turn requires `sebastian/diff ^9`. PHP Insights only allowed `^6.0.2|^7.0.0`, so installing it alongside Pest 5 fails to resolve. The only place we use the package is `Domain\Differ`, and the `Differ` and `StrictUnifiedDiffOutputBuilder` APIs it relies on are unchanged in 9.0, so widening the constraint is enough.
