### PR TITLE
Allow sebastian/diff ^8.0 and ^9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "psr/container": "^2.0.2",
         "psr/simple-cache": "^2.0|^3.0",
-        "sebastian/diff": "^6.0.2|^7.0.0",
+        "sebastian/diff": "^6.0.2|^7.0.0|^8.0|^9.0",
         "slevomat/coding-standard": "^8.22.1",
         "squizlabs/php_codesniffer": "^3.13.5",
         "symfony/cache": "^7.4.5|^8.0.8",


### PR DESCRIPTION
`Domain/Differ.php` uses only `SebastianBergmann\Diff\Differ` and `StrictUnifiedDiffOutputBuilder`, and never passes the `$lcs` parameter — so nothing it touches was affected by the 9.0 removals (`UnifiedDiffOutputBuilder`, `AbstractChunkOutputBuilder`, the `LongestCommonSubsequenceCalculator` interface and its implementations, and the `$lcs` parameter).

Without this, phpinsights transitively blocks consumers from upgrading to **PHPUnit 13 / Pest 5**, which require `sebastian/diff ^9.0`.

Constraint-only change; no source changes.

Related: [cmgmyr/phploc#13](https://github.com/cmgmyr/phploc/pull/13) is the other half — phploc caps `php-file-iterator` at ^6, which blocks the same upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)